### PR TITLE
Correlation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,41 +1,17 @@
 Package: pitShinyApp
 Title: Pituitary Gland Shiny App
-Version: 0.0.1
+Version: 0.0.2
 Date: 2021-10-20
-Depends: R (>= 3.5.0)
+Depends: R (>= 4.0.0)
 Description: Visualizes gene and miRNA expression data from mouse pituitary gland.
-Authors@R: c(person("Cadia", "Chan", role = c("aut", "cre"),
-                    email = "cadia.chan@mail.utoronto.ca"), 
-            person("Huayun", "Hou", role = c("aut"),
-                    email = "huayunhou@gmail.com"),  
-            person("Dustin", "Sokolowski", role = c("aut"),
-                    email = "dustin.sokolowski@sickkids.ca"),
-            person("Sunyun", "Lee", role = c("aut"),
-                    email = "sunyun.lee@mail.utoronto.ca"),
-            person("Mariela", "Fayokoo-Martinez", role = c("aut"),
-                    email = "mfaykoomartinez@gmail.com"),
-            person("Kyoko", "Yuki", role = c("aut"),
-                    email= "kyoko.yuki@sickkids.ca"),
-            person("Anna", "Roy", role = c("aut"),
-                    email = ""),
-            person("Matt", "Hudson", role = c("aut"),
-                    email = "matt.hudson@sickkids.ca"),
-            person("Liis", "Uusküla-Reimand", role = c("aut"),
-                    email = "liis.uuskula-reimand@sickkids.ca"),
-            person("Anna", "Goldenberg", role = c("aut"),
-                    email = "nyulik@gmail.com"),
-            person("Zhaolei", "Zhang", role = c("aut"),
-                    email = "zhaolei.zhang@utoronto.ca"),
-            person("Mark", "Palmert", role = c("aut"),
-                    email = ""),
-            person("Michael", "Wilson", role = c("aut"),
-                    email = "michael.wilson@sickkids.ca"))
+Authors@R: c(person("Cadia", "Chan", role = c("aut", "cre"), email = "cadia.chan@mail.utoronto.ca"), person("Huayun", "Hou", role = c("aut"), email = "huayunhou@gmail.com"), person("Dustin", "Sokolowski", role = c("aut"), email = "dustin.sokolowski@sickkids.ca"), person("Sunyun", "Lee", role = c("aut"), email = "sunyun.lee@mail.utoronto.ca"),person("Mariela", "Fayokoo-Martinez", role = c("aut"),email = "mfaykoomartinez@gmail.com"),person("Kyoko", "Yuki", role = c("aut"),email= "kyoko.yuki@sickkids.ca"),person("Anna", "Roy", role = c("aut"),email = ""),person("Matt", "Hudson", role = c("aut"),email = "matt.hudson@sickkids.ca"),person("Liis", "Uusküla-Reimand", role = c("aut"),email = "liis.uuskula-reimand@sickkids.ca"),person("Anna", "Goldenberg", role = c("aut"),email = "nyulik@gmail.com"),person("Zhaolei", "Zhang", role = c("aut"),email = "zhaolei.zhang@utoronto.ca"),person("Mark", "Palmert", role = c("aut"),email = ""),person("Michael", "Wilson", role = c("aut"),email = "michael.wilson@sickkids.ca"))
 Imports:
-    dplyr,
-    reshape2,
-    ggplot2,
-    shiny,
-    shinyjs
+	dplyr,
+	reshape2,
+	ggplot2,
+	shiny,
+	shinyjs,
+	stringr
 License: GPL-3
 Encoding: UTF-8
 Maintainer: Cadia Chan <cadia.chan@mail.utoronto.ca>

--- a/app.R
+++ b/app.R
@@ -21,10 +21,14 @@ ui <- fluidPage(
                         "(Fix link once data is available)"),
                       br(),
                       h2("Features"),
+                      h3("Data Browser"),
                       p("- Visualize gene and miRNA expression plots across postnatal ages and between sexes."),
                       p("- Quantify log2FC and FDR for DE genes and miRNAs for each comparison."),
-                      p("- Intersect genes of interest with gene lists from relevant published studies."),
+                      p("- Intersect genes of interest with puberty- and pituitary disease-related gene list compendium curated from relevant published studies."),
                       p("- Output normalized and log2(normalized) counts for genes and miRNAs of interest."),
+                      br(),
+                      h3("miRNA-Gene Target Browser"),
+                      p("- "),
                       br(),
                       br(),
                       br(),
@@ -47,8 +51,7 @@ ui <- fluidPage(
                           width = 3,
                           h3("Select input method"),
                           br(),
-                          h4("Gene examples: 'Lhb', 'ENSMUSG00000027120.7'"),
-                          h4("miRNA examples: 'mmu-miR-224-5p', 'miR-383-5p'"),
+                          
                           radioButtons("input_type",
                                        label = NULL,
                                        choices = list("Type in genes/miRNAs" = 1, "Upload file" = 2),
@@ -56,8 +59,6 @@ ui <- fluidPage(
                                        inline = T),
                           uiOutput("add_helper_input"),
                           uiOutput("add_input_ui"),
-                          br(),
-                          
                           div(style="display:inline-block",
                               actionButton("submit",
                                            label = "Submit",
@@ -67,143 +68,8 @@ ui <- fluidPage(
                                            label = "Reset")),
                           br(),
                           br(),
-                          h3("Select studies to intersect"),
-                          checkboxGroupInput("pub_study",
-                                             label = h4("Puberty-related gene lists"),
-                                             choiceNames = list(
-                                               HTML("Perry 2014 <a href = 'https://pubmed.ncbi.nlm.nih.gov/25231870/'>(PMID: 25231870)</a>"),
-                                               HTML("Day 2015 <a href = 'https://pubmed.ncbi.nlm.nih.gov/26548314/'>(PMID: 26548314)</a>"),
-                                               HTML("Day 2017 <a href = 'https://pubmed.ncbi.nlm.nih.gov/28436984/'>(PMID: 28436984)</a>"),
-                                               HTML("Hollis 2020 <a href = 'https://pubmed.ncbi.nlm.nih.gov/32210231/'>(PMID: 32210231)</a>"),
-                                               "IHH/Kallmann"
-                                             ),
-                                             choiceValues = list("Perry2014",
-                                                                 "Day2015_GWAS_VB",
-                                                                 "Day2017_nearest",
-                                                                 "Hollis2020_GWAS_VB_FH",
-                                                                 "IHH/Kallmann"
-                                             ),
-                                             selected = c("Perry2014",
-                                                          "Day2015_GWAS_VB",
-                                                          "Day2017_nearest",
-                                                          "Hollis2020_GWAS_VB_FH",
-                                                          "IHH/Kallmann")),
-                          checkboxGroupInput("pit_study",
-                                             label = h4("Pituitary-related gene lists"),
-                                             choiceNames = list(
-                                               HTML("Ye 2015 <a href = 'https://pubmed.ncbi.nlm.nih.gov/26029870/'>(PMID: 26029870)</a>"),
-                                               HTML("Fang 2016 <a href = 'https://pubmed.ncbi.nlm.nih.gov/27828722/'>(PMID: 27828722)</a>"),
-                                               HTML("Hauser 2019 <a href = 'https://pubmed.ncbi.nlm.nih.gov/31139150/'>(PMID: 31139150)</a>"),
-                                               HTML("Kurtoglu 2019 <a href = 'https://pubmed.ncbi.nlm.nih.gov/29739730/'>(PMID: 29739730)</a>")
-                                             ),
-                                             choiceValues = list("Ye2015_PA_GWAS",
-                                                                 "Fang2016_CPHD",
-                                                                 "Hauser2019_PA",
-                                                                 "Kurtoglu2019_hypopituitarism"
-                                             ),
-                                             selected = c("Ye2015_PA_GWAS",
-                                                          "Fang2016_CPHD",
-                                                          "Hauser2019_PA",
-                                                          "Kurtoglu2019_hypopituitarism")),
-                          downloadButton("save_genelists", "Download gene lists"),
-                          helpText(h5("It is recommended to input <20 genes/miRNAs for viewing on the browser.")),
-                          helpText(h5("If more genes/miRNAs are inputted, expression values and DE table can be downloaded."))
-                        ),
-                        mainPanel(
-                          width = 9,
-                          tabsetPanel(
-                            type = "tabs",
-                            tabPanel(
-                              "Plot",
-                              br(),
-                              verbatimTextOutput("input_err"),
-                              verbatimTextOutput("invalid_genes"),
-                              
-                              column(6,
-                                     br(),
-                                     uiOutput("add_download_gene_plot"),
-                                     h3("Genes"),
-                                     plotOutput("gene_plot",
-                                                height = "auto",
-                                                width = "70%")) ,
-                              column(6,
-                                     br(),
-                                     uiOutput("add_download_mirna_plot"),
-                                     h3("miRNAs"),
-                                     plotOutput("mirna_plot",
-                                                height = "auto",
-                                                width = "70%"))
-                            ),
-                            tabPanel("DE gene table",
-                                     br(),
-                                     uiOutput("add_download_de_gene"),
-                                     tableOutput("de_gene_table"),
-                            ),
-                            tabPanel("DE miRNA table",
-                                     br(),
-                                     uiOutput("add_download_de_mirna"),
-                                     tableOutput("de_mirna_table")),
-                            tabPanel("Gene expression values",
-                                     br(),
-                                     radioButtons("count_type",
-                                                  label = h3("Count type"),
-                                                  choices = list("Normalized counts" = 1, "log2(normCounts)" = 2),
-                                                  selected = 1,
-                                                  inline = T),
-                                     br(),
-                                     uiOutput("add_download_expr_gene"),
-                                     tableOutput("gene_table"),
-                            ),
-                            tabPanel("miRNA expression values",
-                                     br(),
-                                     radioButtons("count_mirna_type",
-                                                  label = h3("Count type"),
-                                                  choices = list("Normalized counts" = 1, "log2(normCounts)" = 2),
-                                                  selected = 1,
-                                                  inline = T),
-                                     br(),
-                                     uiOutput("add_download_expr_mirna"),
-                                     tableOutput("mirna_table")
-                            )
-                          )
-                        )) 
-             ),
-             #### miRNA-gene ####
-             tabPanel(" miRNA-target Gene Browser", icon = icon("project-diagram"),
-                      sidebarLayout(
-                        sidebarPanel(
-                          shinyjs::useShinyjs(),
-                          id = "side-panel_2",
-                          width = 3,
-                          h3("Input a list of genes OR miRNAs"),
-                          # br(),
-                          # h4("Gene examples: 'Lhb', 'ENSMUSG00000027120.7'"),
-                          # h4("miRNA examples: 'mmu-miR-224-5p', 'miR-383-5p'"),
-                          radioButtons("input_type_2",
-                                       label = NULL,
-                                       choices = list("miRNA" = 1, "gene" = 2),
-                                       selected = 1,
-                                       inline = T),
-                          uiOutput("add_helper_input_2"),
-                          uiOutput("add_input_ui_2"),
-                          br(),
-                          helpText(h5("Choose to show only oppositely differentially expressed (DE) miRNA-gene pairs or all miRNA-gene pairs.")),
-                          radioButtons("filt_choice_2",
-                                       label = NULL,
-                                       choices = list("DE" = 1, "All" = 2),
-                                       selected = 1,
-                                       inline = T),
-                          div(style="display:inline-block",
-                              actionButton("submit_2",
-                                           label = "Submit",
-                                           class = "btn-success")),
-                          div(style="display:inline-block",
-                              actionButton("reset_2",
-                                           label = "Reset")),
-                          # br(),
-                          # br(),
-                          # h3("Select studies to intersect with gene targets"),
-                          # checkboxGroupInput("pub_study_2",
+                          # h3("Select studies to intersect"),
+                          # checkboxGroupInput("pub_study",
                           #                    label = h4("Puberty-related gene lists"),
                           #                    choiceNames = list(
                           #                      HTML("Perry 2014 <a href = 'https://pubmed.ncbi.nlm.nih.gov/25231870/'>(PMID: 25231870)</a>"),
@@ -223,7 +89,7 @@ ui <- fluidPage(
                           #                                 "Day2017_nearest",
                           #                                 "Hollis2020_GWAS_VB_FH",
                           #                                 "IHH/Kallmann")),
-                          # checkboxGroupInput("pit_study_2",
+                          # checkboxGroupInput("pit_study",
                           #                    label = h4("Pituitary-related gene lists"),
                           #                    choiceNames = list(
                           #                      HTML("Ye 2015 <a href = 'https://pubmed.ncbi.nlm.nih.gov/26029870/'>(PMID: 26029870)</a>"),
@@ -240,7 +106,127 @@ ui <- fluidPage(
                           #                                 "Fang2016_CPHD",
                           #                                 "Hauser2019_PA",
                           #                                 "Kurtoglu2019_hypopituitarism")),
-                          # downloadButton("save_genelists", "Download gene lists"),
+                          h4("Text input examples:"),
+                          h4("Genes: Lhb,ENSMUSG00000027120.7"),
+                          h4("miRNAs: mmu-miR-224-5p,miR-383-5p"),
+                          br(),
+                          helpText(h5("It is recommended to input <20 genes/miRNAs for viewing on the browser.")),
+                          helpText(h5("If more genes/miRNAs are inputted, expression values and DE table can be downloaded."))
+                        ),
+                        mainPanel(
+                          shinyjs::useShinyjs(),
+                          width = 9,
+                          tabsetPanel(
+                            type = "tabs",
+                            tabPanel(
+                              "Plot",
+                              br(),
+                              verbatimTextOutput("input_err"),
+                              verbatimTextOutput("invalid_genes"),
+                              
+                              column(6,
+                                     br(),
+                                     tags$div(id = "save_gene_plot_text", h4("Save gene expression plots: ")),
+                                     downloadButton("save_png_plot_genes", ".png"),
+                                     downloadButton("save_pdf_plot_genes", ".pdf"),
+                                     h3("Genes"),
+                                     plotOutput("gene_plot",
+                                                height = "auto",
+                                                width = "70%")) ,
+                              column(6,
+                                     br(),
+                                     tags$div(id = "save_mirna_plot_text", h4("Save miRNA expression plots: ")),
+                                     downloadButton("save_png_plot_mirnas", ".png"),
+                                     downloadButton("save_pdf_plot_mirnas", ".pdf"),
+                                     h3("miRNAs"),
+                                     plotOutput("mirna_plot",
+                                                height = "auto",
+                                                width = "70%"))
+                            ),
+                            tabPanel("DE gene table",
+                                     br(),
+                                     radioButtons("de_gene_filt",
+                                                  label = h3("Cutoff for DE gene table"),
+                                                  choices = list("abs(FC) > 1.5, FDR < 0.05" = 1, "No cutoff" = 2),
+                                                  selected = 1,
+                                                  inline = T),
+                                     tags$div(id = "save_de_gene_text", h4("Save DE gene table: ")),
+                                     downloadButton("save_txt_de_genes", ".txt"),
+                                     downloadButton("save_csv_de_genes", ".csv"),
+                                     tableOutput("de_gene_table"),
+                            ),
+                            tabPanel("DE miRNA table",
+                                     br(),
+                                     radioButtons("de_mirna_filt",
+                                                  label = h3("Cutoff for DE miRNA table"),
+                                                  choices = list("abs(FC) > 1.5, FDR < 0.05" = 1, "No cutoff" = 2),
+                                                  selected = 1,
+                                                  inline = T),
+                                     tags$div(id = "save_de_mirna_text", h4("Save DE miRNA table: ")),
+                                     downloadButton("save_txt_de_mirnas", ".txt"),
+                                     downloadButton("save_csv_de_mirnas", ".csv"),
+                                     tableOutput("de_mirna_table")),
+                            tabPanel("Gene expression values",
+                                     br(),
+                                     radioButtons("count_type",
+                                                  label = h3("Count type"),
+                                                  choices = list("Normalized counts" = 1, "log2(normCounts)" = 2),
+                                                  selected = 1,
+                                                  inline = T),
+                                     br(),
+                                     tags$div(id = "save_gene_expr_text", h4("Save gene expression values: ")),
+                                     downloadButton("save_txt_expr_genes", ".txt"),
+                                     downloadButton("save_csv_expr_genes", ".csv"),
+                                     tableOutput("gene_table"),
+                            ),
+                            tabPanel("miRNA expression values",
+                                     br(),
+                                     radioButtons("count_mirna_type",
+                                                  label = h3("Count type"),
+                                                  choices = list("Normalized counts" = 1, "log2(normCounts)" = 2),
+                                                  selected = 1,
+                                                  inline = T),
+                                     br(),
+                                     tags$div(id = "save_mirna_expr_text", h4("Save miRNA expression values: ")),
+                                     downloadButton("save_txt_expr_mirnas", ".txt"),
+                                     downloadButton("save_csv_expr_mirnas", ".csv"),
+                                     tableOutput("mirna_table")
+                            )
+                          )
+                        )) 
+             ),
+             #### miRNA-gene ####
+             tabPanel(" miRNA-Gene Target Browser", icon = icon("project-diagram"),
+                      sidebarLayout(
+                        sidebarPanel(
+                          shinyjs::useShinyjs(),
+                          id = "side-panel_2",
+                          width = 3,
+                          h3("Input a list of genes OR miRNAs"),
+                          # br(),
+                          # h4("Gene examples: 'Lhb', 'ENSMUSG00000027120.7'"),
+                          # h4("miRNA examples: 'mmu-miR-224-5p', 'miR-383-5p'"),
+                          radioButtons("input_type_2",
+                                       label = NULL,
+                                       choices = list("miRNA" = 1, "gene" = 2),
+                                       selected = 1,
+                                       inline = T),
+                          uiOutput("add_helper_input_2"),
+                          uiOutput("add_input_ui_2"),
+                          helpText(h5("Choose to show only differentially expressed (DE) miRNA-gene pairs or all miRNA-gene pairs.")),
+                          radioButtons("filt_choice_2",
+                                       label = NULL,
+                                       choices = list("DE" = 1, "All" = 2),
+                                       selected = 1,
+                                       inline = T),
+                          div(style="display:inline-block",
+                              actionButton("submit_2",
+                                           label = "Submit",
+                                           class = "btn-success")),
+                          div(style="display:inline-block",
+                              actionButton("reset_2",
+                                           label = "Reset")),
+                          br(),
                           helpText(h5("Save and upload tables into Cytoscape to visualize as a network."))
                         ),
                         mainPanel(
@@ -252,8 +238,11 @@ ui <- fluidPage(
                               br(),
                               verbatimTextOutput("input_err_2"),
                               verbatimTextOutput("invalid_genes_2"),
+                              div(style="display:inline-block",
+                                  downloadButton("save_txt_corr_cyto", "Download table in Cytoscape input format")),
+                              div(style="display:inline-block",
+                                  downloadButton("save_txt_corr_input", "Download gene/miRNA list for input to Data Browser")),
                               br(),
-                              # uiOutput("add_download_corr_table"),
                               tableOutput("corr_table")
                             )
                           )
@@ -261,60 +250,69 @@ ui <- fluidPage(
              ),
              #### About ####
              tabPanel("About", icon=icon("quote-left"),
-                      h2("Credits"),
-                      p("Text about this app"),
-                      br(),
+                      # h2("Credits"),
+                      # p("Text about this app"),
+                      # br(),
                       h2("Cite"),
                       h4("Hou H, Chan C, Yuki KE, et al. Postnatal developmental trajectory of sex-biased gene expression in the mouse pituitary gland.",
                          "Manuscript in preparation."),
                       br(),
                       h2("References"),
-                      p("Gene lists are curated from these studies:"),
-                      h4("Perry JR, Day F, Elks CE, et al. Parent-of-origin-specific allelic associations among 106 genomic loci for age at menarche.",
-                         "Nature. 2014;514(7520):92-97.",
-                         a("doi:10.1038/nature13545",
-                           href="https://pubmed.ncbi.nlm.nih.gov/25231870/",
-                           target = "_blank")),
-                      h4("Day FR, Bulik-Sullivan B, Hinds DA, et al. Shared genetic aetiology of puberty timing between sexes and with",
-                         "health-related outcomes. Nat Commun. 2015;6:8842. Published 2015 Nov 9.",
-                         a("doi:10.1038/ncomms9842",
-                           href="https://pubmed.ncbi.nlm.nih.gov/26548314/",
-                           target = "_blank")),
-                      h4("Day FR, Thompson DJ, Helgason H, et al. Genomic analyses identify hundreds of variants associated with age at menarche",
-                         "and support a role for puberty timing in cancer risk. Nat Genet. 2017;49(6):834-841.",
-                         a("doi:10.1038/ng.3841",
-                           href="https://pubmed.ncbi.nlm.nih.gov/28436984/",
-                           target = "_blank")),
-                      h4("Hollis B, Day FR, Busch AS, et al. Genomic analysis of male puberty timing highlights shared genetic basis with hair colour",
-                         "and lifespan. Nat Commun. 2020;11(1):1536. Published 2020 Mar 24.",
-                         a("doi:10.1038/s41467-020-14451-5",
-                           href="https://pubmed.ncbi.nlm.nih.gov/32210231/",
-                           target = "_blank")),
-                      h4("Ye Z, Li Z, Wang Y, et al. Common variants at 10p12.31, 10q21.1 and 13q12.13 are associated with sporadic pituitary adenoma.",
-                         "Nat Genet. 2015;47(7):793-797.",
-                         a("doi:10.1038/ng.3322",
-                           href="https://pubmed.ncbi.nlm.nih.gov/26029870/",
-                           target = "_blank")),
-                      h4("Fang Q, George AS, Brinkmeier ML, et al. Genetics of Combined Pituitary Hormone Deficiency: Roadmap into the Genome Era.",
-                         "Endocr Rev. 2016;37(6):636-675.",
-                         a("doi:10.1210/er.2016-1101",
-                           href="https://pubmed.ncbi.nlm.nih.gov/27828722/",
-                           target = "_blank")),
-                      h4("Hauser BM, Lau A, Gupta S, Bi WL, Dunn IF. The Epigenomics of Pituitary Adenoma.",
-                         "Front Endocrinol (Lausanne). 2019;10:290. Published 2019 May 14.",
-                         a("doi:10.3389/fendo.2019.00290",
-                           href="https://pubmed.ncbi.nlm.nih.gov/31139150/",
-                           target = "_blank")),
-                      h4("Kurtoglu S, Ozdemir A, Hatipoglu N. Neonatal Hypopituitarism: Approaches to Diagnosis and Treatment.",
-                         "J Clin Res Pediatr Endocrinol. 2019;11(1):4-12.",
-                         a("doi:10.4274/jcrpe.galenos.2018.2018.0036",
-                           href="https://pubmed.ncbi.nlm.nih.gov/32210231/",
-                           target = "_blank")),
+                      downloadButton("save_genelists", "Download gene list compendium"),
+                      p("A compendium of puberty-related (#1-4,9) and pituitary gland disease-related (#5-8) gene lists were curated from the following studies:"),
+                      tags$ol(
+                        tags$li(h4("Perry JR, Day F, Elks CE, et al. Parent-of-origin-specific allelic associations among 106 genomic loci for age at menarche.",
+                                   "Nature. 2014;514(7520):92-97. PMID: 25231870.",
+                                   a("doi:10.1038/nature13545",
+                                     href="https://pubmed.ncbi.nlm.nih.gov/25231870/",
+                                     target = "_blank"))),
+                        tags$li(h4("Day FR, Bulik-Sullivan B, Hinds DA, et al. Shared genetic aetiology of puberty timing between sexes and with",
+                                   "health-related outcomes. Nat Commun. 2015;6:8842. Published 2015 Nov 9. PMID: 26548314.",
+                                   a("doi:10.1038/ncomms9842",
+                                     href="https://pubmed.ncbi.nlm.nih.gov/26548314/",
+                                     target = "_blank"))),
+                        tags$li(h4("Day FR, Thompson DJ, Helgason H, et al. Genomic analyses identify hundreds of variants associated with age at menarche",
+                                   "and support a role for puberty timing in cancer risk. Nat Genet. 2017;49(6):834-841. PMID: 28436984.",
+                                   a("doi:10.1038/ng.3841",
+                                     href="https://pubmed.ncbi.nlm.nih.gov/28436984/",
+                                     target = "_blank"))),
+                        tags$li(h4("Hollis B, Day FR, Busch AS, et al. Genomic analysis of male puberty timing highlights shared genetic basis with hair colour",
+                                   "and lifespan. Nat Commun. 2020;11(1):1536. Published 2020 Mar 24. PMID: 32210231.",
+                                   a("doi:10.1038/s41467-020-14451-5",
+                                     href="https://pubmed.ncbi.nlm.nih.gov/32210231/",
+                                     target = "_blank"))),
+                        tags$li(h4("Ye Z, Li Z, Wang Y, et al. Common variants at 10p12.31, 10q21.1 and 13q12.13 are associated with sporadic pituitary adenoma.",
+                                   "Nat Genet. 2015;47(7):793-797. PMID: 26029870.",
+                                   a("doi:10.1038/ng.3322",
+                                     href="https://pubmed.ncbi.nlm.nih.gov/26029870/",
+                                     target = "_blank"))),
+                        tags$li(h4("Fang Q, George AS, Brinkmeier ML, et al. Genetics of Combined Pituitary Hormone Deficiency: Roadmap into the Genome Era.",
+                                   "Endocr Rev. 2016;37(6):636-675. PMID: 27828722.",
+                                   a("doi:10.1210/er.2016-1101",
+                                     href="https://pubmed.ncbi.nlm.nih.gov/27828722/",
+                                     target = "_blank"))),
+                        tags$li( h4("Hauser BM, Lau A, Gupta S, Bi WL, Dunn IF. The Epigenomics of Pituitary Adenoma.",
+                                    "Front Endocrinol (Lausanne). 2019;10:290. Published 2019 May 14. PMID: 31139150.",
+                                    a("doi:10.3389/fendo.2019.00290",
+                                      href="https://pubmed.ncbi.nlm.nih.gov/31139150/",
+                                      target = "_blank"))),
+                        tags$li(h4("Kurtoglu S, Ozdemir A, Hatipoglu N. Neonatal Hypopituitarism: Approaches to Diagnosis and Treatment.",
+                                   "J Clin Res Pediatr Endocrinol. 2019;11(1):4-12. PMID: 29739730.",
+                                   a("doi:10.4274/jcrpe.galenos.2018.2018.0036",
+                                     href="https://pubmed.ncbi.nlm.nih.gov/32210231/",
+                                     target = "_blank"))),
+                        tags$li(h4("Isolated hypogonadotropic hypogonadism (IHH)/Kallmann syndrome.",
+                                   "Gene list previously curated in Hou H, Uusküla-Reimand L, Makarem M, et al.",
+                                   "Gene expression profiling of puberty-associated genes reveals abundant tissue and sex-specific changes across postnatal development.",
+                                   "Hum Mol Genet. 2017;26(18):3585-3599. PMID: 28911201.",
+                                   a("doi:10.1093/hmg/ddx246",
+                                     href="https://pubmed.ncbi.nlm.nih.gov/28911201/",
+                                     target = "_blank")))
+                      ),
                       br(),
                       h2("Funding")
              )
   )
-  # )
 )
 
 
@@ -340,16 +338,39 @@ server <- function(input, output) {
     print(mirna_input)
     print(gene_input)
     
-    if(mirna_input == T | gene_input == T) {
+    if(mirna_input == T & gene_input == F) {
       output$input_err_2 <- NULL
       data_2 <- parse_list(input$gene_2, type = "text")
+      if(length(data_2[["genes"]]) > 0 & length(data_2[["mirnas"]]) > 0) {
+        msg_2 <- paste0("Not a miRNA: ", paste0(data_2[["genes"]], collapse = ","))
+        output$input_err_2 <- renderText({
+          msg_2
+        })
+      }
+      if(length(data_2[["mirnas"]]) == 0) {
+        data_2 <- parse_list("", type = "text")
+        msg_2 <- "Please input a valid list of miRNAs."
+        output$input_err_2 <- renderText({
+          msg_2
+        })
+      }
     }
-    # else if(mirna_input == F & gene_input == T) {
-    #   output$input_err <- NULL
-    #   file <- input$gene
-    #   read_file <- read.table(file$datapath, header = F)
-    #   data <- parse_list(read_file, type = "file")
-    # }
+    else if(mirna_input == F & gene_input == T) {
+      data_2 <- parse_list(input$gene_2, type = "text")
+      if(length(data_2[["mirnas"]]) > 0 & length(data_2[["genes"]]) > 0) {
+        msg_2 <- paste0("Not a gene: ", paste0(data_2[["mirnas"]], collapse = ","))
+        output$input_err_2 <- renderText({
+          msg_2
+        })
+      }
+      if(length(data_2[["genes"]]) == 0) {
+        data_2 <- parse_list("", type = "text")
+        msg_2 <- "Please input a valid list of genes."
+        output$input_err_2 <- renderText({
+          msg_2
+        })
+      }
+    }
     else{ # Print error message if both fields are empty.
       data_2 <- parse_list("", type = "text")
       msg_2 <- "Please input a list of genes/miRNAs."
@@ -389,10 +410,13 @@ server <- function(input, output) {
     }
   })
   
-  
+  shinyjs::hide(id = "save_txt_corr_cyto")
+  shinyjs::hide(id = "save_txt_corr_input")
   # Run functions in response to submit button
   # eventReactive events are delayed until the button is pressed
   press_submit_2 <- eventReactive(input$submit_2, {
+    shinyjs::hide(id = "save_txt_corr_cyto")
+    shinyjs::hide(id = "save_txt_corr_input")
     
     output$invalid_genes_2 <- NULL
     invalid_msg <- "Not found: "
@@ -410,7 +434,7 @@ server <- function(input, output) {
         paste0(invalid_msg, invalid_genes)
       })
     } else{output$invalid_genes_2 <- NULL}
-    print(data_2())
+    # print(data_2())
     if(input$input_type_2 == 1) {
       if(input$filt_choice_2 == 1){
         corrtable <- print_corr_table(mirnalist = data_2()[["mirnas"]])
@@ -431,8 +455,31 @@ server <- function(input, output) {
       }
     }
     
-    return(list("corrtable" = corrtable
-    ))
+    if(ncol(corrtable) > 1) { # Check that corr table is not just an error table with 1 column
+      shinyjs::show(id = "save_txt_corr_cyto")
+      shinyjs::show(id = "save_txt_corr_input")
+    }
+    
+    output$save_txt_corr_cyto <- downloadHandler(
+      filename <- function() {
+        paste0(Sys.Date(), "_corr_table_cytoscape.txt")
+      },
+      content <- function(file) {
+        write.table(corrtable, file,
+                    quote = F, sep = "\t", col.names = T, row.names = F)
+      }
+    )
+    
+    output$save_txt_corr_input <- downloadHandler(
+      filename <- function() {
+        paste0(Sys.Date(), "_corr_gene_mirna_list.txt")
+      },
+      content <- function(file) {
+        write.table(corrtable, file,
+                    quote = F, sep = "\t", col.names = T, row.names = F)
+      }
+    )
+    return(list("corrtable" = corrtable))
   })
   
   # Outputs correlation table
@@ -442,6 +489,8 @@ server <- function(input, output) {
   striped = T,
   hover = T,
   digits = 5)
+  
+
   
   #### Functions for data browser tab ####
   data <- reactive({
@@ -456,11 +505,8 @@ server <- function(input, output) {
       # Check if a file is uploaded
       else if(input$input_type == 2) {
         file_input <- T
-      }else { file_input <- F; text_input <- F}
+      } else { file_input <- F; text_input <- F}
     }
-    
-    # print(text_input)
-    # print(file_input)
     
     if(text_input == T & file_input == F) {
       output$input_err <- NULL
@@ -510,59 +556,49 @@ server <- function(input, output) {
     }
   })
   
-  # Add in save buttons only when valid genes/miRNAs are inputted.
-  add_ui <- function(type) {
-    if(type == "gene") {
-      output$add_download_gene_plot <- renderUI({
-        tagList(
-          h4("Save gene expression plots: "),
-          downloadButton("save_png_plot_genes", ".png"),
-          downloadButton("save_pdf_plot_genes", ".pdf")
-        )
-      })
-      output$add_download_de_gene <- renderUI({
-        tagList(
-          h4("Save DE gene table: "),
-          downloadButton("save_txt_de_genes", ".txt"),
-          downloadButton("save_csv_de_genes", ".csv")
-        )
-      })
-      output$add_download_expr_gene <- renderUI({
-        tagList(
-          h4("Save gene expression values: "),
-          downloadButton("save_txt_expr_genes", ".txt"),
-          downloadButton("save_csv_expr_genes", ".csv")
-        )
-      })
-    }
-    if(type == "mirna") {
-      output$add_download_mirna_plot <- renderUI({
-        tagList(
-          h4("Save miRNA expression plots: "),
-          downloadButton("save_png_plot_mirnas", ".png"),
-          downloadButton("save_pdf_plot_mirnas", ".pdf")
-        )
-      })
-      output$add_download_de_mirna <- renderUI({
-        tagList(
-          h4("Save DE miRNA table: "),
-          downloadButton("save_txt_de_mirnas", ".txt"),
-          downloadButton("save_csv_de_mirnas", ".csv")
-        )
-      })
-      output$add_download_expr_mirna <- renderUI({
-        tagList(
-          h4("Save miRNA expression values: "),
-          downloadButton("save_txt_expr_mirnas", ".txt"),
-          downloadButton("save_csv_expr_mirnas", ".csv")
-        )
-      })
-    }
-  }
+  #### Hide buttons during first initialization ####
+  shinyjs::hide(id = "save_gene_plot_text")
+  shinyjs::hide(id = "save_png_plot_genes")
+  shinyjs::hide(id = "save_pdf_plot_genes")
+  shinyjs::hide(id = "save_de_gene_text")
+  shinyjs::hide(id = "save_txt_de_genes")
+  shinyjs::hide(id = "save_csv_de_genes")
+  shinyjs::hide(id = "save_gene_expr_text")
+  shinyjs::hide(id = "save_txt_expr_genes")
+  shinyjs::hide(id = "save_csv_expr_genes")
+  
+  shinyjs::hide(id = "save_mirna_plot_text")
+  shinyjs::hide(id = "save_png_plot_mirnas")
+  shinyjs::hide(id = "save_pdf_plot_mirnas")
+  shinyjs::hide(id = "save_de_mirna_text")
+  shinyjs::hide(id = "save_txt_de_mirnas")
+  shinyjs::hide(id = "save_csv_de_mirnas")
+  shinyjs::hide(id = "save_mirna_expr_text")
+  shinyjs::hide(id = "save_txt_expr_mirnas")
+  shinyjs::hide(id = "save_csv_expr_mirnas")
   
   # Run functions in response to submit button
   # eventReactive events are delayed until the button is pressed
   press_submit <- eventReactive(input$submit, {
+    shinyjs::hide(id = "save_gene_plot_text")
+    shinyjs::hide(id = "save_png_plot_genes")
+    shinyjs::hide(id = "save_pdf_plot_genes")
+    shinyjs::hide(id = "save_de_gene_text")
+    shinyjs::hide(id = "save_txt_de_genes")
+    shinyjs::hide(id = "save_csv_de_genes")
+    shinyjs::hide(id = "save_gene_expr_text")
+    shinyjs::hide(id = "save_txt_expr_genes")
+    shinyjs::hide(id = "save_csv_expr_genes")
+    
+    shinyjs::hide(id = "save_mirna_plot_text")
+    shinyjs::hide(id = "save_png_plot_mirnas")
+    shinyjs::hide(id = "save_pdf_plot_mirnas")
+    shinyjs::hide(id = "save_de_mirna_text")
+    shinyjs::hide(id = "save_txt_de_mirnas")
+    shinyjs::hide(id = "save_csv_de_mirnas")
+    shinyjs::hide(id = "save_mirna_expr_text")
+    shinyjs::hide(id = "save_txt_expr_mirnas")
+    shinyjs::hide(id = "save_csv_expr_mirnas")
     
     output$invalid_genes <- NULL
     invalid_msg <- "Not found: "
@@ -588,7 +624,12 @@ server <- function(input, output) {
     num_genes <- length(gplot$plot_env$use_genelist)
     
     if(num_genes > 0) {
-      add_ui(type = "gene")
+      shinyjs::show(id = "save_gene_plot_text")
+      shinyjs::show(id = "save_png_plot_genes")
+      shinyjs::show(id = "save_pdf_plot_genes")
+      shinyjs::show(id = "save_gene_expr_text")
+      shinyjs::show(id = "save_txt_expr_genes")
+      shinyjs::show(id = "save_csv_expr_genes")
     }
     
     mplot <- exprplot_hhtheme(genelist = data()[["mirnas"]],
@@ -598,15 +639,31 @@ server <- function(input, output) {
     num_mirnas <- length(mplot$plot_env$use_genelist)
     
     if(num_mirnas > 0) {
-      add_ui(type = "mirna")
+      shinyjs::show(id = "save_mirna_plot_text")
+      shinyjs::show(id = "save_png_plot_mirnas")
+      shinyjs::show(id = "save_pdf_plot_mirnas")
+      shinyjs::show(id = "save_mirna_expr_text")
+      shinyjs::show(id = "save_txt_expr_mirnas")
+      shinyjs::show(id = "save_csv_expr_mirnas")
     }
     
     gtable <- print_de_table(genelist = data()[["genes"]],
                              de_table = utr_de_table,
                              counttype = "genes")
+    
+    gtable_nofilt <- print_de_table(genelist = data()[["genes"]],
+                                    de_table = utr_de_all_table,
+                                    counttype = "genes")
+    gtable <- add_study(gtable)
+    gtable_nofilt <- add_study(gtable_nofilt)
+    
     mtable <- print_de_table(genelist = data()[["mirnas"]],
                              de_table = mirna_de_table,
                              counttype = "mirnas")
+    mtable_nofilt <- print_de_table(genelist = data()[["mirnas"]],
+                                    de_table = mirna_de_all_table,
+                                    counttype = "mirnas")
+    
     norm_data_type <- expr_table(data()[["genes"]], utr_normcounts)
     log2_data_type <- expr_table(data()[["genes"]], utr_log2)
     
@@ -617,7 +674,9 @@ server <- function(input, output) {
                 "mplot" = mplot,
                 "num_mirnas" = num_mirnas,
                 "gtable" = gtable,
+                "gtable_nofilt" = gtable_nofilt,
                 "mtable" = mtable,
+                "mtable_nofilt" = mtable_nofilt,
                 "norm_data_type" = norm_data_type,
                 "log2_data_type" = log2_data_type,
                 "norm_mirna_data_type" = norm_mirna_data_type,
@@ -625,16 +684,195 @@ server <- function(input, output) {
   })
   
   # observed events occur the moment the button is pressed
+  # Switches DE table between DE GENE table with cutoff and DE GENE table without cutoff
+  # Also switches save buttons
+  observeEvent(input$submit, {
+    observeEvent(input$de_gene_filt, {
+      gene_de <- press_submit()
+      if(input$de_gene_filt == 1) {
+        gene_de_table <- gene_de[["gtable"]]
+        if(ncol(gene_de_table) > 1) {
+          shinyjs::show(id = "save_de_gene_text")
+          shinyjs::show(id = "save_txt_de_genes")
+          shinyjs::show(id = "save_csv_de_genes")
+        }
+        # Save as txt file with DE filt
+        output$save_txt_de_genes <- downloadHandler(
+          filename <- function() {
+            paste0(Sys.Date(), "_de_genes.txt")
+          },
+          content <- function(file) {
+            write.table(gene_de_table, file,
+                        quote = F, sep = "\t", col.names = T, row.names = F)
+          }
+        )
+        # Save as csv file with DE filt
+        output$save_csv_de_genes <- downloadHandler(
+          filename <- function() {
+            paste0(Sys.Date(), "_de_genes.csv")
+          },
+          content <- function(file) {
+            write.csv(gene_de_table, file,
+                      quote = F, row.names = F)
+          }
+        )
+      }
+      if(input$de_gene_filt == 2) {
+        gene_de_table <- gene_de[["gtable_nofilt"]]
+        if(ncol(gene_de_table) > 1) {
+          shinyjs::show(id = "save_de_gene_text")
+          shinyjs::show(id = "save_txt_de_genes")
+          shinyjs::show(id = "save_csv_de_genes")
+        }
+        # Save as txt file with no DE filt
+        output$save_txt_de_genes <- downloadHandler(
+          filename <- function() {
+            paste0(Sys.Date(), "_de_nofilt_genes.txt")
+          },
+          content <- function(file) {
+            write.table(gene_de_table, file,
+                        quote = F, sep = "\t", col.names = T, row.names = F)
+          }
+        )
+        # Save as csv file with no DE filt
+        output$save_csv_de_genes <- downloadHandler(
+          filename <- function() {
+            paste0(Sys.Date(), "_de_nofilt_genes.csv")
+          },
+          content <- function(file) {
+            write.csv(gene_de_table, file,
+                      quote = F, row.names = F)
+          }
+        )
+      }
+      output$de_gene_table <- renderTable({
+        gene_de_table
+      },
+      striped = T,
+      hover = T,
+      digits = 5)
+    })
+  })
+  
+  # observed events occur the moment the button is pressed
+  # Switches DE table between DE miRNA table with cutoff and DE miRNA table without cutoff
+  # Also switches save buttons
+  observeEvent(input$submit, {
+    observeEvent(input$de_mirna_filt, {
+      mirna_de <- press_submit()
+      if(input$de_mirna_filt == 1) {
+        mirna_de_table <- mirna_de[["mtable"]]
+        if(ncol(mirna_de_table) > 1) {
+          shinyjs::show(id = "save_de_mirna_text")
+          shinyjs::show(id = "save_txt_de_mirnas")
+          shinyjs::show(id = "save_csv_de_mirnas")
+        }
+        # Save as text file with DE filt
+        output$save_txt_de_mirnas <- downloadHandler(
+          filename <- function() {
+            paste0(Sys.Date(), "_de_mirnas.txt")
+          },
+          content <- function(file) { 
+            write.table(mirna_de_table, file,
+                        quote = F, sep = "\t", col.names = T, row.names = F)
+          }
+        )
+        # Save as csv file with DE filt
+        output$save_csv_de_mirnas <- downloadHandler(
+          filename <- function() {
+            paste0(Sys.Date(), "_de_mirnas.csv")
+          },
+          content <- function(file) {
+            write.csv(mirna_de_table[["mtable"]], file,
+                      quote = F, row.names = F)
+          }
+        )
+      }
+      if(input$de_mirna_filt == 2) {
+        mirna_de_table <- mirna_de[["mtable_nofilt"]]
+        if(ncol(mirna_de_table) > 1) {
+          shinyjs::show(id = "save_de_mirna_text")
+          shinyjs::show(id = "save_txt_de_mirnas")
+          shinyjs::show(id = "save_csv_de_mirnas")
+        }
+        # Save as txt file with no DE filt
+        output$save_txt_de_mirnas <- downloadHandler(
+          filename <- function() {
+            paste0(Sys.Date(), "_de_nofilt_mirnas.txt")
+          },
+          content <- function(file) { 
+            write.table(mirna_de_table, file,
+                        quote = F, sep = "\t", col.names = T, row.names = F)
+          }
+        )
+        # Save as csv file with no DE filt
+        output$save_csv_de_mirnas <- downloadHandler(
+          filename <- function() {
+            paste0(Sys.Date(), "_de_nofilt_mirnas.csv")
+          },
+          content <- function(file) {
+            write.csv(mirna_de_table, file,
+                      quote = F, row.names = F)
+          }
+        )
+      }
+      output$de_mirna_table <- renderTable({
+        mirna_de_table
+      },
+      striped = T,
+      hover = T,
+      digits = 5)
+    })
+  })
+  
+  # observed events occur the moment the button is pressed
   # Switches output table between normalized and log2norm gene counts
   observeEvent(input$submit, {
     observeEvent(input$count_type, {
+      gene_expr <- press_submit()
       if(input$count_type == 1) {
-        data_type <- press_submit()[["norm_data_type"]]
-        err_gene_tab <- press_submit()[["norm_err_gene_tab"]]
+        data_type <- gene_expr[["norm_data_type"]]
+        err_gene_tab <- gene_expr[["norm_err_gene_tab"]]
+        df_out_type <- (as.data.frame(cbind(sample=rownames(data_type), data_type)))
+        output$save_txt_expr_genes <- downloadHandler(
+          filename <- function() {
+            paste0(Sys.Date(), "_norm_expression_genes.txt")
+          },
+          content <- function(file) {
+            write.table(df_out_type, file,
+                        quote = F, sep = "\t", col.names = T, row.names = F)
+          }
+        )
+        output$save_csv_expr_genes <- downloadHandler(
+          filename <- function() {
+            paste0(Sys.Date(), "_norm_expression_genes.csv")
+          },
+          content <- function(file) {
+            write.csv(df_out_type, file, quote = F, row.names = F)
+          }
+        )
       }
       if(input$count_type == 2) {
-        data_type <- press_submit()[["log2_data_type"]]
-        err_gene_tab <- press_submit()[["log2_err_gene_tab"]]
+        data_type <- gene_expr[["log2_data_type"]]
+        err_gene_tab <- gene_expr[["log2_err_gene_tab"]]
+        df_out_type <- (as.data.frame(cbind(sample=rownames(data_type), data_type)))
+        output$save_txt_expr_genes <- downloadHandler(
+          filename <- function() {
+            paste0(Sys.Date(), "_log2_expression_genes.txt")
+          },
+          content <- function(file) {
+            write.table(df_out_type, file,
+                        quote = F, sep = "\t", col.names = T, row.names = F)
+          }
+        )
+        output$save_csv_expr_genes <- downloadHandler(
+          filename <- function() {
+            paste0(Sys.Date(), "_norm_expression_genes.csv")
+          },
+          content <- function(file) {
+            write.csv(df_out_type, file, quote = F, row.names = F)
+          }
+        )
       }
       output$gene_table <- renderTable({
         data_type
@@ -645,16 +883,54 @@ server <- function(input, output) {
     })
   })
   
+  
   # Switches output table between normalized and log2norm miRNA counts
   observeEvent(input$submit, {
     observeEvent(input$count_mirna_type, {
+      mirna_expr <- press_submit()
       if(input$count_mirna_type == 1) {
-        mirna_data_type <- press_submit()[["norm_mirna_data_type"]]
-        mirna_err_gene_tab <- press_submit()[["norm_err_mirna_tab"]]
+        mirna_data_type <- mirna_expr[["norm_mirna_data_type"]]
+        mirna_err_gene_tab <- mirna_expr[["norm_err_mirna_tab"]]
+        df_out_type <- (as.data.frame(cbind(sample=rownames(mirna_data_type), mirna_data_type)))
+        
+        output$save_txt_expr_mirnas <- downloadHandler(
+          filename <- function() {
+            paste0(Sys.Date(), "_norm_expression_mirnas.txt")
+          },
+          content <- function(file) {
+            write.table(df_out_type, file, quote = F, sep = "\t", col.names = T, row.names = F)
+          }
+        )
+        output$save_csv_expr_mirnas <- downloadHandler(
+          filename <- function() {
+            paste0(Sys.Date(), "_norm_expression_mirnas.csv")
+          },
+          content <- function(file) {
+            write.csv(df_out_type, file, quote = F, row.names = F)
+          }
+        )
       }
       if(input$count_mirna_type == 2) {
-        mirna_data_type <- press_submit()[["log2_mirna_data_type"]]
-        mirna_err_gene_tab <- press_submit()[["log2_err_mirna_tab"]]
+        mirna_data_type <- mirna_expr[["log2_mirna_data_type"]]
+        mirna_err_gene_tab <- mirna_expr[["log2_err_mirna_tab"]]
+        df_out_type <- (as.data.frame(cbind(sample=rownames(mirna_data_type), mirna_data_type)))
+        
+        output$save_txt_expr_mirnas <- downloadHandler(
+          filename <- function() {
+            paste0(Sys.Date(), "_log2_expression_mirnas.txt")
+          },
+          content <- function(file) {
+            write.table(df_out_type, file, quote = F, sep = "\t", col.names = T, row.names = F)
+          }
+        )
+        output$save_csv_expr_mirnas <- downloadHandler(
+          filename <- function() {
+            paste0(Sys.Date(), "_log2_expression_mirnas.csv")
+          },
+          content <- function(file) {
+            write.csv(df_out_type, file, quote = F, row.names = F)
+          }
+        )
       }
       output$mirna_table <- renderTable({
         mirna_data_type
@@ -665,22 +941,6 @@ server <- function(input, output) {
     })
   })
   
-  observeEvent(input$submit, {
-    observeEvent(input$pub_study, {
-      if(length(input$pub_study) > 0) {
-        output$de_gene_table <- renderTable({
-          de_genes <- press_submit()[["gtable"]]
-          return(add_study(de_genes,
-                           input$pub_study))
-        },
-        striped = T,
-        hover = T,
-        digits = 5)
-      }
-    })
-  })
-  
-  
   # Outputs gene plots
   # Plot heights are scaled by number of genes to plot
   output$gene_plot <- renderPlot({
@@ -690,11 +950,12 @@ server <- function(input, output) {
   height = function() {
     use_height <- press_submit()[["num_genes"]]
     if(use_height > 0) {
-      return(use_height*325)
+      return(use_height*300)
     }
-    else {return(325)}# Height of 1 plot
+    else {return(300)}# Height of 1 plot
   })
   
+  #### miRNA plot outputs ####
   # Outputs miRNA plots
   # Plot heights are scaled by number of miRNAs to plot
   output$mirna_plot <- renderPlot({
@@ -704,26 +965,11 @@ server <- function(input, output) {
   height = function() {
     use_height <- press_submit()[["num_mirnas"]]
     if(use_height > 0) {
-      return(use_height*325)
+      return(use_height*300)
     }
-    else { return(325)} # Height of 1 plot
+    else { return(300)} # Height of 1 plot
   })
   
-  # Outputs DE gene table
-  output$de_gene_table <- renderTable({
-    press_submit()[["gtable"]]
-  },
-  striped = T,
-  hover = T,
-  digits = 5)
-  
-  # Outputs DE miRNA table
-  output$de_mirna_table <- renderTable({
-    press_submit()[["mtable"]]
-  },
-  striped = T,
-  hover = T,
-  digits = 5)
   
   output$save_png_plot_genes <- downloadHandler(
     filename <- function() {
@@ -777,126 +1023,8 @@ server <- function(input, output) {
     },
   )  
   
-  output$save_txt_de_genes <- downloadHandler(
-    filename <- function() {
-      paste0(Sys.Date(), "_de_genes.txt")
-    },
-    content <- function(file) {
-      write.table(press_submit()[["gtable"]], file,
-                  quote = F, sep = "\t", col.names = T, row.names = F)
-    }
-  )
-  
-  output$save_txt_de_mirnas <- downloadHandler(
-    filename <- function() {
-      paste0(Sys.Date(), "_de_mirnas.txt")
-    },
-    content <- function(file) { 
-      write.table(press_submit()[["mtable"]], file,
-                  quote = F, sep = "\t", col.names = T, row.names = F)
-    }
-  )
-  
-  output$save_csv_de_genes <- downloadHandler(
-    filename <- function() {
-      paste0(Sys.Date(), "_de_genes.csv")
-    },
-    content <- function(file) {
-      write.csv(press_submit()[["gtable"]], file,
-                quote = F, row.names = F)
-    }
-  )
-  
-  output$save_csv_de_mirnas <- downloadHandler(
-    filename <- function() {
-      paste0(Sys.Date(), "_de_mirnas.csv")
-    },
-    content <- function(file) {
-      write.csv(press_submit()[["mtable"]], file,
-                quote = F, row.names = F)
-    }
-  )
-  
-  output$save_txt_expr_genes <- downloadHandler(
-    filename <- function() {
-      paste0(Sys.Date(), "_expression_genes.txt")
-    },
-    content <- function(file) {
-      df_out <- press_submit()
-      if(input$count_type == 1) {
-        df_out_type <- df_out[["norm_data_type"]]
-        df_out_type <- (as.data.frame(cbind(sample=rownames(df_out_type), df_out_type)))
-        
-      }
-      if(input$count_type == 2) {
-        df_out_type <- df_out[["log2_data_type"]]
-        df_out_type <- (as.data.frame(cbind(sample=rownames(df_out_type), df_out_type)))
-      }
-      write.table(df_out_type, file,
-                  quote = F, sep = "\t", col.names = T, row.names = F)
-    }
-  )
-  
-  output$save_csv_expr_genes <- downloadHandler(
-    filename <- function() {
-      paste0(Sys.Date(), "_expression_genes.csv")
-    },
-    content <- function(file) {
-      df_out <- press_submit()
-      if(input$count_type == 1) {
-        df_out_type <- df_out[["norm_data_type"]]
-        df_out_type <- (as.data.frame(cbind(sample=rownames(df_out_type), df_out_type)))
-        
-      }
-      if(input$count_type == 2) {
-        df_out_type <- df_out[["log2_data_type"]]
-        df_out_type <- (as.data.frame(cbind(sample=rownames(df_out_type), df_out_type)))
-      }
-      write.csv(df_out_type, file,
-                quote = F, row.names = F)
-    }
-  )
-  
-  output$save_txt_expr_mirnas <- downloadHandler(
-    filename <- function() {
-      paste0(Sys.Date(), "_expression_mirnas.txt")
-    },
-    content <- function(file) {
-      df_out <- press_submit()
-      if(input$count_type == 1) {
-        df_out_type <- df_out[["norm_mirna_data_type"]]
-        df_out_type <- (as.data.frame(cbind(sample=rownames(df_out_type), df_out_type)))
-        
-      }
-      if(input$count_type == 2) {
-        df_out_type <- df_out[["log2_mirna_data_type"]]
-        df_out_type <- (as.data.frame(cbind(sample=rownames(df_out_type), df_out_type)))
-      }
-      write.table(df_out_type, file,
-                  quote = F, sep = "\t", col.names = T, row.names = F)
-    }
-  )
-  
-  output$save_csv_expr_mirnas <- downloadHandler(
-    filename <- function() {
-      paste0(Sys.Date(), "_expression_mirnas.csv")
-    },
-    content <- function(file) {
-      df_out <- press_submit()
-      if(input$count_type == 1) {
-        df_out_type <- df_out[["norm_mirna_data_type"]]
-        df_out_type <- (as.data.frame(cbind(sample=rownames(df_out_type), df_out_type)))
-        
-      }
-      if(input$count_type == 2) {
-        df_out_type <- df_out[["log2_mirna_data_type"]]
-        df_out_type <- (as.data.frame(cbind(sample=rownames(df_out_type), df_out_type)))
-      }
-      write.csv(df_out_type, file,
-                quote = F, row.names = F)
-    }
-  )
-  
+  # Save button is on About page
+  # Curated gene list from studies listed on About page
   output$save_genelists <- downloadHandler(
     filename <- function() {
       paste0(Sys.Date(), "_study_gene_lists.txt")

--- a/app.R
+++ b/app.R
@@ -8,6 +8,7 @@ ui <- fluidPage(
   ),
   # shinyUI(
   navbarPage("Mouse Pituitary Gland Data Hub",
+             #### Home ####
              tabPanel("Home",icon = icon("home"),
                       h1("MOUSE PITUITARY GLAND DATA HUB"),
                       br(),
@@ -37,6 +38,7 @@ ui <- fluidPage(
                       p("- qPCR tab from Hou et al 2017"),
                       p("- Add filter for sex-bias or age-bias in DE tables (redundant feature of default lists?)")
              ),
+             #### Data Browser ####
              tabPanel("Data Browser", icon = icon("chart-bar"),
                       sidebarLayout(
                         sidebarPanel(
@@ -44,8 +46,11 @@ ui <- fluidPage(
                           id = "side-panel",
                           width = 3,
                           h3("Select input method"),
+                          br(),
+                          h4("Gene examples: 'Lhb', 'ENSMUSG00000027120.7'"),
+                          h4("miRNA examples: 'mmu-miR-224-5p', 'miR-383-5p'"),
                           radioButtons("input_type",
-                                       label = h4("Input type"),
+                                       label = NULL,
                                        choices = list("Type in genes/miRNAs" = 1, "Upload file" = 2),
                                        selected = 1,
                                        inline = T),
@@ -92,9 +97,9 @@ ui <- fluidPage(
                                                HTML("Kurtoglu 2019 <a href = 'https://pubmed.ncbi.nlm.nih.gov/29739730/'>(PMID: 29739730)</a>")
                                              ),
                                              choiceValues = list("Ye2015_PA_GWAS",
-                                                            "Fang2016_CPHD",
-                                                            "Hauser2019_PA",
-                                                            "Kurtoglu2019_hypopituitarism"
+                                                                 "Fang2016_CPHD",
+                                                                 "Hauser2019_PA",
+                                                                 "Kurtoglu2019_hypopituitarism"
                                              ),
                                              selected = c("Ye2015_PA_GWAS",
                                                           "Fang2016_CPHD",
@@ -163,55 +168,150 @@ ui <- fluidPage(
                           )
                         )) 
              ),
+             #### miRNA-gene ####
+             tabPanel(" miRNA-target Gene Browser", icon = icon("project-diagram"),
+                      sidebarLayout(
+                        sidebarPanel(
+                          shinyjs::useShinyjs(),
+                          id = "side-panel_2",
+                          width = 3,
+                          h3("Input a list of genes OR miRNAs"),
+                          # br(),
+                          # h4("Gene examples: 'Lhb', 'ENSMUSG00000027120.7'"),
+                          # h4("miRNA examples: 'mmu-miR-224-5p', 'miR-383-5p'"),
+                          radioButtons("input_type_2",
+                                       label = NULL,
+                                       choices = list("miRNA" = 1, "gene" = 2),
+                                       selected = 1,
+                                       inline = T),
+                          uiOutput("add_helper_input_2"),
+                          uiOutput("add_input_ui_2"),
+                          br(),
+                          helpText(h5("Choose to show only oppositely differentially expressed (DE) miRNA-gene pairs or all miRNA-gene pairs.")),
+                          radioButtons("filt_choice_2",
+                                       label = NULL,
+                                       choices = list("DE" = 1, "All" = 2),
+                                       selected = 1,
+                                       inline = T),
+                          div(style="display:inline-block",
+                              actionButton("submit_2",
+                                           label = "Submit",
+                                           class = "btn-success")),
+                          div(style="display:inline-block",
+                              actionButton("reset_2",
+                                           label = "Reset")),
+                          # br(),
+                          # br(),
+                          # h3("Select studies to intersect with gene targets"),
+                          # checkboxGroupInput("pub_study_2",
+                          #                    label = h4("Puberty-related gene lists"),
+                          #                    choiceNames = list(
+                          #                      HTML("Perry 2014 <a href = 'https://pubmed.ncbi.nlm.nih.gov/25231870/'>(PMID: 25231870)</a>"),
+                          #                      HTML("Day 2015 <a href = 'https://pubmed.ncbi.nlm.nih.gov/26548314/'>(PMID: 26548314)</a>"),
+                          #                      HTML("Day 2017 <a href = 'https://pubmed.ncbi.nlm.nih.gov/28436984/'>(PMID: 28436984)</a>"),
+                          #                      HTML("Hollis 2020 <a href = 'https://pubmed.ncbi.nlm.nih.gov/32210231/'>(PMID: 32210231)</a>"),
+                          #                      "IHH/Kallmann"
+                          #                    ),
+                          #                    choiceValues = list("Perry2014",
+                          #                                        "Day2015_GWAS_VB",
+                          #                                        "Day2017_nearest",
+                          #                                        "Hollis2020_GWAS_VB_FH",
+                          #                                        "IHH/Kallmann"
+                          #                    ),
+                          #                    selected = c("Perry2014",
+                          #                                 "Day2015_GWAS_VB",
+                          #                                 "Day2017_nearest",
+                          #                                 "Hollis2020_GWAS_VB_FH",
+                          #                                 "IHH/Kallmann")),
+                          # checkboxGroupInput("pit_study_2",
+                          #                    label = h4("Pituitary-related gene lists"),
+                          #                    choiceNames = list(
+                          #                      HTML("Ye 2015 <a href = 'https://pubmed.ncbi.nlm.nih.gov/26029870/'>(PMID: 26029870)</a>"),
+                          #                      HTML("Fang 2016 <a href = 'https://pubmed.ncbi.nlm.nih.gov/27828722/'>(PMID: 27828722)</a>"),
+                          #                      HTML("Hauser 2019 <a href = 'https://pubmed.ncbi.nlm.nih.gov/31139150/'>(PMID: 31139150)</a>"),
+                          #                      HTML("Kurtoglu 2019 <a href = 'https://pubmed.ncbi.nlm.nih.gov/29739730/'>(PMID: 29739730)</a>")
+                          #                    ),
+                          #                    choiceValues = list("Ye2015_PA_GWAS",
+                          #                                        "Fang2016_CPHD",
+                          #                                        "Hauser2019_PA",
+                          #                                        "Kurtoglu2019_hypopituitarism"
+                          #                    ),
+                          #                    selected = c("Ye2015_PA_GWAS",
+                          #                                 "Fang2016_CPHD",
+                          #                                 "Hauser2019_PA",
+                          #                                 "Kurtoglu2019_hypopituitarism")),
+                          # downloadButton("save_genelists", "Download gene lists"),
+                          helpText(h5("Save and upload tables into Cytoscape to visualize as a network."))
+                        ),
+                        mainPanel(
+                          width = 9,
+                          tabsetPanel(
+                            type = "tabs",
+                            tabPanel(
+                              "miRNA-target genes",
+                              br(),
+                              verbatimTextOutput("input_err_2"),
+                              verbatimTextOutput("invalid_genes_2"),
+                              br(),
+                              # uiOutput("add_download_corr_table"),
+                              tableOutput("corr_table")
+                            )
+                          )
+                        )) 
+             ),
+             #### About ####
              tabPanel("About", icon=icon("quote-left"),
                       h2("Credits"),
                       p("Text about this app"),
                       br(),
-                      h2("Citations"),
+                      h2("Cite"),
                       h4("Hou H, Chan C, Yuki KE, et al. Postnatal developmental trajectory of sex-biased gene expression in the mouse pituitary gland.",
-                        "Manuscript in preparation."),
+                         "Manuscript in preparation."),
                       br(),
+                      h2("References"),
                       p("Gene lists are curated from these studies:"),
                       h4("Perry JR, Day F, Elks CE, et al. Parent-of-origin-specific allelic associations among 106 genomic loci for age at menarche.",
-                      "Nature. 2014;514(7520):92-97.",
-                      a("doi:10.1038/nature13545",
-                        href="https://pubmed.ncbi.nlm.nih.gov/25231870/",
-                        target = "_blank")),
+                         "Nature. 2014;514(7520):92-97.",
+                         a("doi:10.1038/nature13545",
+                           href="https://pubmed.ncbi.nlm.nih.gov/25231870/",
+                           target = "_blank")),
                       h4("Day FR, Bulik-Sullivan B, Hinds DA, et al. Shared genetic aetiology of puberty timing between sexes and with",
-                      "health-related outcomes. Nat Commun. 2015;6:8842. Published 2015 Nov 9.",
-                        a("doi:10.1038/ncomms9842",
-                          href="https://pubmed.ncbi.nlm.nih.gov/26548314/",
-                          target = "_blank")),
+                         "health-related outcomes. Nat Commun. 2015;6:8842. Published 2015 Nov 9.",
+                         a("doi:10.1038/ncomms9842",
+                           href="https://pubmed.ncbi.nlm.nih.gov/26548314/",
+                           target = "_blank")),
                       h4("Day FR, Thompson DJ, Helgason H, et al. Genomic analyses identify hundreds of variants associated with age at menarche",
-                      "and support a role for puberty timing in cancer risk. Nat Genet. 2017;49(6):834-841.",
-                        a("doi:10.1038/ng.3841",
-                          href="https://pubmed.ncbi.nlm.nih.gov/28436984/",
-                          target = "_blank")),
+                         "and support a role for puberty timing in cancer risk. Nat Genet. 2017;49(6):834-841.",
+                         a("doi:10.1038/ng.3841",
+                           href="https://pubmed.ncbi.nlm.nih.gov/28436984/",
+                           target = "_blank")),
                       h4("Hollis B, Day FR, Busch AS, et al. Genomic analysis of male puberty timing highlights shared genetic basis with hair colour",
-                      "and lifespan. Nat Commun. 2020;11(1):1536. Published 2020 Mar 24.",
-                        a("doi:10.1038/s41467-020-14451-5",
-                          href="https://pubmed.ncbi.nlm.nih.gov/32210231/",
-                          target = "_blank")),
+                         "and lifespan. Nat Commun. 2020;11(1):1536. Published 2020 Mar 24.",
+                         a("doi:10.1038/s41467-020-14451-5",
+                           href="https://pubmed.ncbi.nlm.nih.gov/32210231/",
+                           target = "_blank")),
                       h4("Ye Z, Li Z, Wang Y, et al. Common variants at 10p12.31, 10q21.1 and 13q12.13 are associated with sporadic pituitary adenoma.",
-                      "Nat Genet. 2015;47(7):793-797.",
-                        a("doi:10.1038/ng.3322",
-                          href="https://pubmed.ncbi.nlm.nih.gov/26029870/",
-                          target = "_blank")),
+                         "Nat Genet. 2015;47(7):793-797.",
+                         a("doi:10.1038/ng.3322",
+                           href="https://pubmed.ncbi.nlm.nih.gov/26029870/",
+                           target = "_blank")),
                       h4("Fang Q, George AS, Brinkmeier ML, et al. Genetics of Combined Pituitary Hormone Deficiency: Roadmap into the Genome Era.",
-                      "Endocr Rev. 2016;37(6):636-675.",
-                        a("doi:10.1210/er.2016-1101",
-                          href="https://pubmed.ncbi.nlm.nih.gov/27828722/",
-                          target = "_blank")),
+                         "Endocr Rev. 2016;37(6):636-675.",
+                         a("doi:10.1210/er.2016-1101",
+                           href="https://pubmed.ncbi.nlm.nih.gov/27828722/",
+                           target = "_blank")),
                       h4("Hauser BM, Lau A, Gupta S, Bi WL, Dunn IF. The Epigenomics of Pituitary Adenoma.",
-                      "Front Endocrinol (Lausanne). 2019;10:290. Published 2019 May 14.",
-                        a("doi:10.3389/fendo.2019.00290",
-                          href="https://pubmed.ncbi.nlm.nih.gov/31139150/",
-                          target = "_blank")),
+                         "Front Endocrinol (Lausanne). 2019;10:290. Published 2019 May 14.",
+                         a("doi:10.3389/fendo.2019.00290",
+                           href="https://pubmed.ncbi.nlm.nih.gov/31139150/",
+                           target = "_blank")),
                       h4("Kurtoglu S, Ozdemir A, Hatipoglu N. Neonatal Hypopituitarism: Approaches to Diagnosis and Treatment.",
-                      "J Clin Res Pediatr Endocrinol. 2019;11(1):4-12.",
-                        a("doi:10.4274/jcrpe.galenos.2018.2018.0036",
-                          href="https://pubmed.ncbi.nlm.nih.gov/32210231/",
-                          target = "_blank")),
+                         "J Clin Res Pediatr Endocrinol. 2019;11(1):4-12.",
+                         a("doi:10.4274/jcrpe.galenos.2018.2018.0036",
+                           href="https://pubmed.ncbi.nlm.nih.gov/32210231/",
+                           target = "_blank")),
+                      br(),
+                      h2("Funding")
              )
   )
   # )
@@ -221,7 +321,129 @@ ui <- fluidPage(
 
 # Define server logic ----
 server <- function(input, output) {
+  #### Functions for miRNA-gene tab ####
+  data_2 <- reactive({
+    mirna_input <- F
+    gene_input <- F
+    # print(input$gene)
+    if(!is.null(input$gene_2)) {
+      # Check if genes are inputted by text box
+      if(input$input_type_2 == 1 & nchar(input$gene_2) > 0) {
+        mirna_input <- T
+      }
+      # Check if a file is uploaded
+      else if(input$input_type_2 == 2) {
+        gene_input <- T
+      }else { mirna_input <- F; gene_input <- F}
+    }
+    
+    print(mirna_input)
+    print(gene_input)
+    
+    if(mirna_input == T | gene_input == T) {
+      output$input_err_2 <- NULL
+      data_2 <- parse_list(input$gene_2, type = "text")
+    }
+    # else if(mirna_input == F & gene_input == T) {
+    #   output$input_err <- NULL
+    #   file <- input$gene
+    #   read_file <- read.table(file$datapath, header = F)
+    #   data <- parse_list(read_file, type = "file")
+    # }
+    else{ # Print error message if both fields are empty.
+      data_2 <- parse_list("", type = "text")
+      msg_2 <- "Please input a list of genes/miRNAs."
+      output$input_err_2 <- renderText({
+        msg_2
+      })
+    }
+    return(data_2)
+  })
   
+  # Reset input values in the side-panel
+  observeEvent(input$reset_2, {
+    shinyjs::reset("side-panel_2")
+  })
+  
+  # Add in UI based on input choice
+  observeEvent(input$input_type_2, {
+    if(input$input_type_2 == 1) {
+      output$add_helper_input_2 <- renderUI({
+        helpText(h5("Separate miRNAs with a comma"))
+      })
+      output$add_input_ui_2 <- renderUI({
+        textInput("gene_2", label = NULL,
+                  placeholder = "let-7a-5p,mmu-let-7e-5p,miR-224-5p"
+        )
+      })
+    }
+    if(input$input_type_2 == 2) {
+      output$add_helper_input_2 <- renderUI({
+        helpText(h5("Separate genes with a comma"))
+      })
+      output$add_input_ui_2 <- renderUI({
+        textInput("gene_2", label = NULL,
+                  placeholder = "Lhb,ENSMUSG00000027120.7,Gh,Prl"
+        )
+      })
+    }
+  })
+  
+  
+  # Run functions in response to submit button
+  # eventReactive events are delayed until the button is pressed
+  press_submit_2 <- eventReactive(input$submit_2, {
+    
+    output$invalid_genes_2 <- NULL
+    invalid_msg <- "Not found: "
+    invalid_genes <- paste(data_2()[["invalid"]], collapse = ",")
+    if(identical(data_2()[["invalid"]], character(0))) {
+      output$invalid_genes_2 <- NULL
+    }
+    else if(length(data_2()[["invalid"]]) > 1) {
+      output$invalid_genes_2 <- renderText({
+        paste0(invalid_msg, invalid_genes)
+      })
+    }
+    else if(length(data_2()[["invalid"]]) == 1 & data_2()[["invalid"]] != "") {
+      output$invalid_genes_2 <- renderText({
+        paste0(invalid_msg, invalid_genes)
+      })
+    } else{output$invalid_genes_2 <- NULL}
+    print(data_2())
+    if(input$input_type_2 == 1) {
+      if(input$filt_choice_2 == 1){
+        corrtable <- print_corr_table(mirnalist = data_2()[["mirnas"]])
+      }
+      else {
+        corrtable <- print_corr_table(mirnalist = data_2()[["mirnas"]],
+                                      de_filt = F)
+      }
+    }
+    
+    if(input$input_type_2 == 2) {
+      if(input$filt_choice_2 == 1){
+        corrtable <- print_corr_table(genelist = data_2()[["genes"]])
+      }
+      else {
+        corrtable <- print_corr_table(genelist = data_2()[["genes"]],
+                                      de_filt = F)
+      }
+    }
+    
+    return(list("corrtable" = corrtable
+    ))
+  })
+  
+  # Outputs correlation table
+  output$corr_table <- renderTable({
+    press_submit_2()[["corrtable"]]
+  },
+  striped = T,
+  hover = T,
+  digits = 5)
+  
+  #### Functions for data browser tab ####
   data <- reactive({
     text_input <- F
     file_input <- F
@@ -446,7 +668,6 @@ server <- function(input, output) {
   observeEvent(input$submit, {
     observeEvent(input$pub_study, {
       if(length(input$pub_study) > 0) {
-        print(input$pub_study)
         output$de_gene_table <- renderTable({
           de_genes <- press_submit()[["gtable"]]
           return(add_study(de_genes,
@@ -469,9 +690,9 @@ server <- function(input, output) {
   height = function() {
     use_height <- press_submit()[["num_genes"]]
     if(use_height > 0) {
-      return(use_height*375)
+      return(use_height*325)
     }
-    else {return(350)}# Height of 1 plot
+    else {return(325)}# Height of 1 plot
   })
   
   # Outputs miRNA plots
@@ -483,9 +704,9 @@ server <- function(input, output) {
   height = function() {
     use_height <- press_submit()[["num_mirnas"]]
     if(use_height > 0) {
-      return(use_height*375)
+      return(use_height*325)
     }
-    else { return(350)} # Height of 1 plot
+    else { return(325)} # Height of 1 plot
   })
   
   # Outputs DE gene table

--- a/app.R
+++ b/app.R
@@ -21,31 +21,38 @@ ui <- fluidPage(
                         "(Fix link once data is available)"),
                       br(),
                       h2("Features"),
+                      br(),
                       h3("Data Browser"),
-                      p("- Visualize gene and miRNA expression plots across postnatal ages and between sexes."),
-                      p("- Quantify log2FC and FDR for DE genes and miRNAs for each comparison."),
-                      p("- Intersect genes of interest with puberty- and pituitary disease-related gene list compendium curated from relevant published studies."),
-                      p("- Output normalized and log2(normalized) counts for genes and miRNAs of interest."),
+                      tags$ul(
+                        tags$li(p("Visualize gene and miRNA expression plots across postnatal ages and between sexes.")),
+                        tags$li(p("Quantify log2FC and FDR for DE genes and miRNAs for each comparison (with or without cutoffs).")),
+                        tags$li(p("Intersect genes of interest with puberty- and pituitary disease-related gene list compendium curated from relevant published studies.")),
+                        tags$li(p("Output normalized and log2(normalized) counts for genes and miRNAs of interest."))
+                      ),
                       br(),
                       h3("miRNA-Gene Target Browser"),
-                      p("- "),
+                      tags$ul(
+                        tags$li(p("Explore miRNAs and their negatively correlated gene targets.")),
+                        tags$li(p("Output miRNA-gene targets as input for Cytoscape to visualize results as a miRNA-gene network")),
+                        tags$li(p("Output the list of miRNAs and their gene targets as input for Data Browser to visualize their expression and quantify their differential expression."))
+                      ),
                       br(),
                       br(),
                       br(),
-                      h2("To-do <priority>"),
-                      p("- Add in miRNA-gene correlation tab"),
-                      p("- Add in default lists to show DE genes and miRNAs from comparisons in the manuscript"),
-                      p("- Design graphical abstract for <Home> tab"),
-                      br(),
-                      h2("To-do <possible things to add>"),
-                      p("- Add cell-type specificity to DE genes based on scMappR results?"),
-                      p("- qPCR tab from Hou et al 2017"),
-                      p("- Add filter for sex-bias or age-bias in DE tables (redundant feature of default lists?)")
+                      # h2("To-do <priority>"),
+                      # p("- Add in default lists to show DE genes and miRNAs from comparisons in the manuscript"),
+                      # p("- Design graphical abstract for <Home> tab"),
+                      # br(),
+                      # h2("To-do <possible things to add>"),
+                      # p("- Add cell-type specificity to DE genes based on scMappR results?"),
+                      # p("- qPCR tab from Hou et al 2017"),
+                      # p("- Add filter for sex-bias or age-bias in DE tables (redundant feature of default lists?)")
              ),
              #### Data Browser ####
              tabPanel("Data Browser", icon = icon("chart-bar"),
                       sidebarLayout(
                         sidebarPanel(
+                          
                           shinyjs::useShinyjs(),
                           id = "side-panel",
                           width = 3,
@@ -54,9 +61,9 @@ ui <- fluidPage(
                           
                           radioButtons("input_type",
                                        label = NULL,
-                                       choices = list("Type in genes/miRNAs" = 1, "Upload file" = 2),
-                                       selected = 1,
-                                       inline = T),
+                                       choices = list("Type in genes/miRNAs" = 1, "Upload file" = 2,
+                                                      "Sex-biased genes and miRNAs" = 3),
+                                       selected = 1),
                           uiOutput("add_helper_input"),
                           uiOutput("add_input_ui"),
                           div(style="display:inline-block",
@@ -68,50 +75,12 @@ ui <- fluidPage(
                                            label = "Reset")),
                           br(),
                           br(),
-                          # h3("Select studies to intersect"),
-                          # checkboxGroupInput("pub_study",
-                          #                    label = h4("Puberty-related gene lists"),
-                          #                    choiceNames = list(
-                          #                      HTML("Perry 2014 <a href = 'https://pubmed.ncbi.nlm.nih.gov/25231870/'>(PMID: 25231870)</a>"),
-                          #                      HTML("Day 2015 <a href = 'https://pubmed.ncbi.nlm.nih.gov/26548314/'>(PMID: 26548314)</a>"),
-                          #                      HTML("Day 2017 <a href = 'https://pubmed.ncbi.nlm.nih.gov/28436984/'>(PMID: 28436984)</a>"),
-                          #                      HTML("Hollis 2020 <a href = 'https://pubmed.ncbi.nlm.nih.gov/32210231/'>(PMID: 32210231)</a>"),
-                          #                      "IHH/Kallmann"
-                          #                    ),
-                          #                    choiceValues = list("Perry2014",
-                          #                                        "Day2015_GWAS_VB",
-                          #                                        "Day2017_nearest",
-                          #                                        "Hollis2020_GWAS_VB_FH",
-                          #                                        "IHH/Kallmann"
-                          #                    ),
-                          #                    selected = c("Perry2014",
-                          #                                 "Day2015_GWAS_VB",
-                          #                                 "Day2017_nearest",
-                          #                                 "Hollis2020_GWAS_VB_FH",
-                          #                                 "IHH/Kallmann")),
-                          # checkboxGroupInput("pit_study",
-                          #                    label = h4("Pituitary-related gene lists"),
-                          #                    choiceNames = list(
-                          #                      HTML("Ye 2015 <a href = 'https://pubmed.ncbi.nlm.nih.gov/26029870/'>(PMID: 26029870)</a>"),
-                          #                      HTML("Fang 2016 <a href = 'https://pubmed.ncbi.nlm.nih.gov/27828722/'>(PMID: 27828722)</a>"),
-                          #                      HTML("Hauser 2019 <a href = 'https://pubmed.ncbi.nlm.nih.gov/31139150/'>(PMID: 31139150)</a>"),
-                          #                      HTML("Kurtoglu 2019 <a href = 'https://pubmed.ncbi.nlm.nih.gov/29739730/'>(PMID: 29739730)</a>")
-                          #                    ),
-                          #                    choiceValues = list("Ye2015_PA_GWAS",
-                          #                                        "Fang2016_CPHD",
-                          #                                        "Hauser2019_PA",
-                          #                                        "Kurtoglu2019_hypopituitarism"
-                          #                    ),
-                          #                    selected = c("Ye2015_PA_GWAS",
-                          #                                 "Fang2016_CPHD",
-                          #                                 "Hauser2019_PA",
-                          #                                 "Kurtoglu2019_hypopituitarism")),
                           h4("Text input examples:"),
                           h4("Genes: Lhb,ENSMUSG00000027120.7"),
                           h4("miRNAs: mmu-miR-224-5p,miR-383-5p"),
                           br(),
                           helpText(h5("It is recommended to input <20 genes/miRNAs for viewing on the browser.")),
-                          helpText(h5("If more genes/miRNAs are inputted, expression values and DE table can be downloaded."))
+                          helpText(h5("If more genes/miRNAs are inputted, expression values and DE table can be downloaded.")),
                         ),
                         mainPanel(
                           shinyjs::useShinyjs(),
@@ -124,36 +93,69 @@ ui <- fluidPage(
                               verbatimTextOutput("input_err"),
                               verbatimTextOutput("invalid_genes"),
                               
-                              column(6,
+                              column(5,
                                      br(),
+                                     h3("Genes"),
                                      tags$div(id = "save_gene_plot_text", h4("Save gene expression plots: ")),
                                      downloadButton("save_png_plot_genes", ".png"),
                                      downloadButton("save_pdf_plot_genes", ".pdf"),
-                                     h3("Genes"),
                                      plotOutput("gene_plot",
                                                 height = "auto",
                                                 width = "70%")) ,
-                              column(6,
+                              column(5,
                                      br(),
+                                     h3("miRNAs"),
                                      tags$div(id = "save_mirna_plot_text", h4("Save miRNA expression plots: ")),
                                      downloadButton("save_png_plot_mirnas", ".png"),
                                      downloadButton("save_pdf_plot_mirnas", ".pdf"),
-                                     h3("miRNAs"),
                                      plotOutput("mirna_plot",
                                                 height = "auto",
-                                                width = "70%"))
+                                                width = "70%")),
+                              column(2,
+                                     sidebarPanel(
+                                       style = ("position:fixed;width:inherited"),
+                                       width = 2,
+                                       h4("Study ID"),
+                                       h5("1. Perry2014"),
+                                       h5("2. Day2015"),
+                                       h5("3. Day2017"),
+                                       h5("4. Hollis2020"),
+                                       h5("5. Ye2015"),
+                                       h5("6. Fang2016"),
+                                       h5("7. Hauser2019"),
+                                       h5("8. Kurtoglu2019"),
+                                       h5("9. IHH/Kallmann")
+                                     )
+                              )
                             ),
                             tabPanel("DE gene table",
                                      br(),
-                                     radioButtons("de_gene_filt",
-                                                  label = h3("Cutoff for DE gene table"),
-                                                  choices = list("abs(FC) > 1.5, FDR < 0.05" = 1, "No cutoff" = 2),
-                                                  selected = 1,
-                                                  inline = T),
-                                     tags$div(id = "save_de_gene_text", h4("Save DE gene table: ")),
-                                     downloadButton("save_txt_de_genes", ".txt"),
-                                     downloadButton("save_csv_de_genes", ".csv"),
-                                     tableOutput("de_gene_table"),
+                                     column(width = 10,
+                                            radioButtons("de_gene_filt",
+                                                         label = h3("Cutoff for DE gene table"),
+                                                         choices = list("abs(FC) > 1.5, FDR < 0.05" = 1, "No cutoff" = 2),
+                                                         selected = 1,
+                                                         inline = T),
+                                            tags$div(id = "save_de_gene_text", h4("Save DE gene table: ")),
+                                            downloadButton("save_txt_de_genes", ".txt"),
+                                            downloadButton("save_csv_de_genes", ".csv"),
+                                            
+                                            tableOutput("de_gene_table")),
+                                     column(width = 2,
+                                            sidebarPanel(
+                                              style = ("position:fixed;width:inherited"),
+                                              width = 2,
+                                              h4("Study ID"),
+                                              h5("1. Perry2014"),
+                                              h5("2. Day2015"),
+                                              h5("3. Day2017"),
+                                              h5("4. Hollis2020"),
+                                              h5("5. Ye2015"),
+                                              h5("6. Fang2016"),
+                                              h5("7. Hauser2019"),
+                                              h5("8. Kurtoglu2019"),
+                                              h5("9. IHH/Kallmann")
+                                            ))
                             ),
                             tabPanel("DE miRNA table",
                                      br(),
@@ -193,60 +195,89 @@ ui <- fluidPage(
                                      tableOutput("mirna_table")
                             )
                           )
-                        )) 
+                        )
+                      )
              ),
              #### miRNA-gene ####
              tabPanel(" miRNA-Gene Target Browser", icon = icon("project-diagram"),
                       sidebarLayout(
-                        sidebarPanel(
-                          shinyjs::useShinyjs(),
-                          id = "side-panel_2",
-                          width = 3,
-                          h3("Input a list of genes OR miRNAs"),
-                          # br(),
-                          # h4("Gene examples: 'Lhb', 'ENSMUSG00000027120.7'"),
-                          # h4("miRNA examples: 'mmu-miR-224-5p', 'miR-383-5p'"),
-                          radioButtons("input_type_2",
-                                       label = NULL,
-                                       choices = list("miRNA" = 1, "gene" = 2),
-                                       selected = 1,
-                                       inline = T),
-                          uiOutput("add_helper_input_2"),
-                          uiOutput("add_input_ui_2"),
-                          helpText(h5("Choose to show only differentially expressed (DE) miRNA-gene pairs or all miRNA-gene pairs.")),
-                          radioButtons("filt_choice_2",
-                                       label = NULL,
-                                       choices = list("DE" = 1, "All" = 2),
-                                       selected = 1,
-                                       inline = T),
-                          div(style="display:inline-block",
-                              actionButton("submit_2",
-                                           label = "Submit",
-                                           class = "btn-success")),
-                          div(style="display:inline-block",
-                              actionButton("reset_2",
-                                           label = "Reset")),
-                          br(),
-                          helpText(h5("Save and upload tables into Cytoscape to visualize as a network."))
-                        ),
-                        mainPanel(
-                          width = 9,
-                          tabsetPanel(
-                            type = "tabs",
-                            tabPanel(
-                              "miRNA-target genes",
-                              br(),
-                              verbatimTextOutput("input_err_2"),
-                              verbatimTextOutput("invalid_genes_2"),
-                              div(style="display:inline-block",
-                                  downloadButton("save_txt_corr_cyto", "Download table in Cytoscape input format")),
-                              div(style="display:inline-block",
-                                  downloadButton("save_txt_corr_input", "Download gene/miRNA list for input to Data Browser")),
-                              br(),
-                              tableOutput("corr_table")
-                            )
+                      sidebarPanel(
+                        shinyjs::useShinyjs(),
+                        id = "side-panel_2",
+                        width = 3,
+                        h3("Input a list of genes OR miRNAs"),
+                        br(),
+                        radioButtons("input_type_2",
+                                     label = NULL,
+                                     choices = list("miRNA" = 1, "gene" = 2),
+                                     selected = 1,
+                                     inline = T),
+                        uiOutput("add_helper_input_2"),
+                        uiOutput("add_input_ui_2"),
+                        helpText(h5("Choose to show only differentially expressed (DE) miRNA-gene pairs or all miRNA-gene pairs.")),
+                        radioButtons("filt_choice_2",
+                                     label = NULL,
+                                     choices = list("DE" = 1, "All" = 2),
+                                     selected = 1,
+                                     inline = T),
+                        div(style="display:inline-block",
+                            actionButton("submit_2",
+                                         label = "Submit",
+                                         class = "btn-success")),
+                        div(style="display:inline-block",
+                            actionButton("reset_2",
+                                         label = "Reset")),
+                        br(),
+                        # br(),
+                        # h4("Input examples:"),
+                        # h4("Genes: Ammecr1,Inhba"),
+                        # h4("miRNAs: mmu-miR-224-5p,miR-181a-5p"),
+                        br(),
+                        tags$ol(
+                          tags$li(h5("Save and upload nodes and edges into Cytoscape to visualize as a network."),
+                                  tags$ul(
+                                    tags$li(a(h5("Create network with edges file"),
+                                              href="http://manual.cytoscape.org/en/stable/Creating_Networks.html",
+                                              target = "_blank")),
+                                    tags$li(a(h5("Add information wth nodes file"),
+                                              href="https://manual.cytoscape.org/en/stable/Node_and_Edge_Column_Data.html",
+                                              target = "_blank"))
+                                  )
+                          ),
+                          tags$li(
+                            h5("Upload gene/miRNA list to Data Browser to visualize expression patterns and look at differential expression.")
                           )
-                        )) 
+                        )
+                      ),
+                      mainPanel(
+                        width = 9,
+                        tabsetPanel(
+                          type = "tabs",
+                          tabPanel(
+                            "miRNA-target genes",
+                            br(),
+                            verbatimTextOutput("input_err_2"),
+                            verbatimTextOutput("invalid_genes_2"),
+                            column(6,
+                                   br(),
+                                   tags$div(id = "cytoscape_text", h4("For Cytoscape input:")),
+                                   div(style="display:inline-block",
+                                       downloadButton("save_txt_corr_cyto_nodes", "Download nodes")),
+                                   div(style="display:inline-block",
+                                       downloadButton("save_txt_corr_cyto", "Download edges"))
+                            ),
+                            column(6,
+                                   br(),
+                                   tags$div(id = "browser_input_text", h4("For Data Browser input:")),
+                                   div(style="display:inline-block",
+                                       downloadButton("save_txt_corr_input", "Download gene/miRNA list"))
+                            ),
+                            br(),
+                            tableOutput("corr_table")
+                          )
+                        )
+                      )
+                      )
              ),
              #### About ####
              tabPanel("About", icon=icon("quote-left"),
@@ -409,14 +440,20 @@ server <- function(input, output) {
       })
     }
   })
-  
+  shinyjs::hide(id = "browser_input_text")
+  shinyjs::hide(id = "cytoscape_text")
   shinyjs::hide(id = "save_txt_corr_cyto")
   shinyjs::hide(id = "save_txt_corr_input")
+  shinyjs::hide(id = "save_txt_corr_cyto_nodes")
   # Run functions in response to submit button
   # eventReactive events are delayed until the button is pressed
   press_submit_2 <- eventReactive(input$submit_2, {
+    shinyjs::hide(id = "browser_input_text")
+    shinyjs::hide(id = "cytoscape_text")
     shinyjs::hide(id = "save_txt_corr_cyto")
     shinyjs::hide(id = "save_txt_corr_input")
+    shinyjs::hide(id = "save_txt_corr_cyto_nodes")
+    
     
     output$invalid_genes_2 <- NULL
     invalid_msg <- "Not found: "
@@ -456,8 +493,11 @@ server <- function(input, output) {
     }
     
     if(ncol(corrtable) > 1) { # Check that corr table is not just an error table with 1 column
+      shinyjs::show(id = "browser_input_text")
+      shinyjs::show(id = "cytoscape_text")
       shinyjs::show(id = "save_txt_corr_cyto")
       shinyjs::show(id = "save_txt_corr_input")
+      shinyjs::show(id = "save_txt_corr_cyto_nodes")
     }
     
     output$save_txt_corr_cyto <- downloadHandler(
@@ -465,18 +505,37 @@ server <- function(input, output) {
         paste0(Sys.Date(), "_corr_table_cytoscape.txt")
       },
       content <- function(file) {
-        write.table(corrtable, file,
+        corrtable_cyto <- dplyr::select(corrtable, mirna, gene, rho, database)
+        write.table(corrtable_cyto, file,
                     quote = F, sep = "\t", col.names = T, row.names = F)
       }
     )
+    corrtable_cyto_nodes <- bind_rows(list(dplyr::select(corrtable, mirna, mirna_comparison) %>%
+                                             dplyr::rename(node = mirna, comparison = mirna_comparison),
+                                           dplyr::select(corrtable, gene, gene_comparison) %>%
+                                             dplyr::rename(node = gene, comparison = gene_comparison))) %>%
+      mutate(node_type = ifelse(grepl("mmu-", node), "mirna", "gene"))
     
+    output$save_txt_corr_cyto_nodes <- downloadHandler(
+      filename <- function() {
+        paste0(Sys.Date(), "_corr_nodes_cytoscape.txt")
+      },
+      content <- function(file) {
+        # corrtable_cyto_nodes <- dplyr::select(corrtable, mirna, gene, gene_comparison, mirna_comparison) %>%
+        #   mutate(node_type = ifelse(grepl("mmu-", mirna), "mirna", "gene"))
+        
+        write.table(corrtable_cyto_nodes, file,
+                    quote = F, sep = "\t", col.names = T, row.names = F)
+      }
+    )
     output$save_txt_corr_input <- downloadHandler(
       filename <- function() {
         paste0(Sys.Date(), "_corr_gene_mirna_list.txt")
       },
       content <- function(file) {
-        write.table(corrtable, file,
-                    quote = F, sep = "\t", col.names = T, row.names = F)
+        corrtable_list <- data.frame(matrix(c(corrtable$mirna, corrtable$gene), ncol = 1))
+        write.table(corrtable_list, file,
+                    quote = F, sep = "\t", col.names = F, row.names = F)
       }
     )
     return(list("corrtable" = corrtable))
@@ -490,40 +549,48 @@ server <- function(input, output) {
   hover = T,
   digits = 5)
   
-
+  
   
   #### Functions for data browser tab ####
   data <- reactive({
     text_input <- F
     file_input <- F
-    # print(input$gene)
-    if(!is.null(input$gene)) {
-      # Check if genes are inputted by text box
-      if(input$input_type == 1 & nchar(input$gene) > 0) {
-        text_input <- T
-      } 
-      # Check if a file is uploaded
-      else if(input$input_type == 2) {
-        file_input <- T
-      } else { file_input <- F; text_input <- F}
-    }
-    
-    if(text_input == T & file_input == F) {
-      output$input_err <- NULL
-      data <- parse_list(input$gene, type = "text")
-    }
-    else if(text_input == F & file_input == T) {
-      output$input_err <- NULL
-      file <- input$gene
-      read_file <- read.table(file$datapath, header = F)
-      data <- parse_list(read_file, type = "file")
-    }
-    else{ # Print error message if both fields are empty.
-      data <- parse_list("", type = "text")
-      msg <- "Please input a list of genes/miRNAs."
-      output$input_err <- renderText({
-        msg
-      })
+    if(input$input_type == 3) {
+      print(input$sex_comparison)
+      utr_de_cut <- unique(filter(utr_de_table, comparison == input$sex_comparison))
+      mirna_de_cut <- unique(filter(mirna_de_table, comparison == input$sex_comparison))
+      combine_cut <- bind_rows(list(utr_de_cut[,"ID", drop = F], mirna_de_cut[, "ID", drop = F]))
+      data <- parse_list(paste0(combine_cut$ID, collapse = ","), type = "text")
+    } else {
+      # print(input$gene)
+      if(!is.null(input$gene)) {
+        # Check if genes are inputted by text box
+        if(input$input_type == 1 & nchar(input$gene) > 0) {
+          text_input <- T
+        } 
+        # Check if a file is uploaded
+        else if(input$input_type == 2) {
+          file_input <- T
+        } else { file_input <- F; text_input <- F}
+      }
+      
+      if(text_input == T & file_input == F) {
+        output$input_err <- NULL
+        data <- parse_list(input$gene, type = "text")
+      }
+      else if(text_input == F & file_input == T) {
+        output$input_err <- NULL
+        file <- input$gene
+        read_file <- read.table(file$datapath, header = F)
+        data <- parse_list(read_file, type = "file")
+      }
+      else{ # Print error message if both fields are empty.
+        data <- parse_list("", type = "text")
+        msg <- "Please input a list of genes/miRNAs."
+        output$input_err <- renderText({
+          msg
+        })
+      }
     }
     return(data)
   })
@@ -552,6 +619,23 @@ server <- function(input, output) {
       })
       output$add_input_ui <- renderUI({
         fileInput("gene", label = NULL, accept = ".txt")
+      })
+    }
+    if(input$input_type == 3) {
+      output$add_helper_input <- renderUI({
+        HTML(paste(h5("Select age for sex-biased gene/miRNA list from Hou et al 2022."),
+                   h5("* Some comparisons make take longer to load due to a greater number of miRNAs and genes."),
+                   sep = '</\n/>'))
+      })
+      output$add_input_ui <- renderUI({
+        radioButtons("sex_comparison",
+                     label = NULL,
+                     choices = list("PD12" = "d12_sex",
+                                    "PD22" = "d22_sex",
+                                    "PD27*" = "d27_sex",
+                                    "PD32*" = "d32_sex",
+                                    "PD37*" = "d37_sex"),
+                     selected = 1)
       })
     }
   })
@@ -950,10 +1034,11 @@ server <- function(input, output) {
   height = function() {
     use_height <- press_submit()[["num_genes"]]
     if(use_height > 0) {
-      return(use_height*300)
+      return(use_height*280)
     }
-    else {return(300)}# Height of 1 plot
-  })
+    else {return(280)}# Height of 1 plot
+  },
+  width = 375)
   
   #### miRNA plot outputs ####
   # Outputs miRNA plots
@@ -968,7 +1053,8 @@ server <- function(input, output) {
       return(use_height*300)
     }
     else { return(300)} # Height of 1 plot
-  })
+  },
+  width = 375)
   
   
   output$save_png_plot_genes <- downloadHandler(

--- a/scripts.R
+++ b/scripts.R
@@ -2,6 +2,7 @@
 library(dplyr)
 library(reshape2)
 library(ggplot2)
+library(stringr)
 # source("http://bioconductor.org/biocLite.R")
 # biocLite("EDASeq")
 
@@ -44,12 +45,18 @@ names(utr_de) <- c(names(utr_de)[1:5],
 
 # Reformat DE tables
 utr_de_table <- bind_rows(lapply(names(utr_de), function(x) mutate(utr_de[[x]], comparison = x)))
+utr_de_all_table <- utr_de_table[,c(7,1,2,6,8)] %>%
+  mutate(FDR = -log10(FDR)) %>%
+  dplyr::rename(ensembl_id = genes, ID = genename, log2FC = logFC, `-log10(FDR)` = FDR)
 utr_de_table <- utr_de_table[,c(7,1,2,6,8)] %>%
   filter(., abs(logFC) > log2(1.5) & FDR < 0.05) %>%
   mutate(FDR = -log10(FDR)) %>%
   dplyr::rename(ensembl_id = genes, ID = genename, log2FC = logFC, `-log10(FDR)` = FDR)
 
 mirna_de_table <- bind_rows(lapply(names(mirna_de), function(x) mutate(mirna_de[[x]], comparison = x)))
+mirna_de_all_table <-  mirna_de_table[,c(1,2,6,ncol(mirna_de_table))] %>%
+  mutate(FDR = -log10(FDR)) %>%
+  dplyr::rename(ID = genes, log2FC = logFC, `-log10(FDR)` = FDR)
 mirna_de_table <- mirna_de_table[,c(1,2,6,ncol(mirna_de_table))] %>%
   filter(., abs(logFC) > log2(1.5) & FDR < 0.05) %>%
   mutate(FDR = -log10(FDR)) %>%
@@ -65,7 +72,6 @@ pub_genes_split <- data.frame(ID = rep.int(pub_genes$gene_symbol, sapply(splitte
                               source = unlist(splitted))
 
 
-
 # Parse input gene list
 # Precompute ensembl gene ids from gene symbols present as rownames in utr object using biomart.
 # Script only loads in the dataframe
@@ -78,7 +84,7 @@ pub_genes_split <- data.frame(ID = rep.int(pub_genes$gene_symbol, sapply(splitte
 # saveRDS(ensemble2gene, "data/20211015_ensembl_gene_id_mgi_biomart_conversion.rds")
 
 gene_ensembl_convert <- readRDS("data/20211015_ensembl_gene_id_mgi_biomart_conversion.rds")
-genelist <- "let-7a-5p,mmu-let-7e-5p,ENSMUSG00000027120.7,test"
+# genelist <- "let-7a-5p,mmu-let-7e-5p,test,fshb,ENsmUSG00000027120.7,mmu-miR-224-5p,mir-224-5p,MIR-383-5P"
 # genelist <- "let-7a-5p,mmu-let-7e-5p,test"
 # genelist <- "ENSMUSG00000027120.7,test" # need to fix
 # genelist <- "test"
@@ -86,6 +92,7 @@ genelist <- "let-7a-5p,mmu-let-7e-5p,ENSMUSG00000027120.7,test"
 parse_list <- function(genelist, type) {
   if(type == "text") {
     genelist <- unlist(strsplit(genelist, ","))
+    genelist <- gsub(" ", "", genelist) # In case user inputs comma separated with space
   }
   
   if(type == "file") {
@@ -94,21 +101,22 @@ parse_list <- function(genelist, type) {
   
   
   # 1: match gene symbols with utr row names
-  keep_genes <- genelist[which(genelist %in% rownames(utr_normcounts))]
+  keep_genes <- str_to_sentence(genelist[which(tolower(genelist) %in% tolower(rownames(utr_normcounts)))])
   if(length(keep_genes) > 0) {
-    genelist <- genelist[-which(genelist %in% keep_genes)]
+    genelist <- genelist[-which(tolower(genelist) %in% tolower(keep_genes))]
   } 
   
   
   # 2: try to convert non-matches from ensembl ID to gene symbol
   # Parse string for "ENSMUSG" to find a mouse ensembl genes
-  ens_match <- genelist[grep("ENSMUSG", genelist)]
+  ens_match <- genelist[grep("ENSMUSG", genelist, ignore.case = T)] 
   ensid_match <- ens_match[grep(".", ens_match, fixed = T)]
   ens_match <- ens_match[-grep(".", ens_match, fixed = T)]
   
+
   use_gene_ensembl_convert <- filter(gene_ensembl_convert,
-                                     ensembl_gene_id %in% ens_match |
-                                       ensembl_gene_id_version %in% ensid_match)$mgi_symbol
+                                     ensembl_gene_id %in% toupper(ens_match) |   # Ensure ENS matches are upper case
+                                       ensembl_gene_id_version %in% toupper(ensid_match))$mgi_symbol   # Ensure ENS matches are upper case
   keep_genes <- c(keep_genes, use_gene_ensembl_convert) # this is a valid gene list
   
   # 3A: match non-matches with mirna row names
@@ -116,6 +124,7 @@ parse_list <- function(genelist, type) {
     genelist <- genelist[-c(which(genelist %in% ens_match), which(genelist %in% ensid_match))]
   }
   
+  genelist <- gsub("mir", "miR", tolower(genelist), ignore.case = T) # Allows users to enter mirna ids without case sensitive format
   keep_mirnas <- genelist[which(genelist %in% rownames(mirna_normcounts))]
   
   if(length(keep_mirnas) > 0) {
@@ -223,45 +232,63 @@ exprplot_hhtheme <- function(genelist,
 print_de_table <- function(genelist,
                            de_table,
                            counttype) {
+  
   if(length(genelist) > 0) {
     dtable <- filter(de_table, ID %in% genelist) %>%
       arrange(desc(abs(log2FC)))
-  }
-  else {
+  } else {
     dtable <- data.frame(paste0("No ", counttype, " inputted."))
     colnames(dtable) <- ""
   }
   
   if(nrow(dtable) == 0) {
-    dtable <- data.frame(paste0(genelist, " is not DE."))
+    dtable <- data.frame(paste0(genelist, " does not pass set cutoff."))
     colnames(dtable) <- ""
-  }
-  # print(dtable)
+  } 
+  # else {
+  #   if(counttype == "genes") {
+  #     pub_genes_use <- filter(pub_genes_split, source %in% unique(pub_genes_split$source))
+  #     dtable <- left_join(dtable, pub_genes_use, by = "ID")
+  #     dtable <- dtable %>% group_by(ID, ensembl_id, log2FC, `-log10(FDR)`, comparison) %>%
+  #       summarise(source  = toString(source)) %>%
+  #       arrange(desc(abs(log2FC)))
+  #   }
+  # }
   return(dtable)
 }
 
-add_study <- function(use_table, study) {
-  pub_genes_use <- filter(pub_genes_split, source %in% study)
-  utr_de_merge <- left_join(use_table, pub_genes_use, by = "ID")
-  utr_de_merge <- utr_de_merge %>% group_by(ID, ensembl_id, log2FC, `-log10(FDR)`, comparison) %>%
-    summarise(source  = toString(source)) %>%
-    arrange(desc(abs(log2FC)))
-  return(utr_de_merge)
+pub_genes_key <- as.data.frame(matrix(c(1:9, c("Perry2014", "Day2015_GWAS_VB",
+                              "Day2017_nearest", "Hollis2020_GWAS_VB_FH",
+                              "Ye2015_PA_GWAS", "Fang2016_CPHD",
+                              "Hauser2019_PA", "Kurtoglu2019_hypopituitarism",
+                              "IHH/Kallmann")), ncol = 2,
+                     dimnames = list(NULL,c("study_id", "source"))))
+pub_genes_split <- left_join(pub_genes_split, pub_genes_key, by = "source")
+
+add_study <- function(use_table, study=unique(pub_genes_split$study_id)) {
+  if(ncol(use_table) > 1) { # Check to see that dataframe has DE info and is not just an error message
+    pub_genes_use <- filter(pub_genes_split, study_id %in% study)
+    utr_de_merge <- left_join(use_table, pub_genes_use, by = "ID")
+    utr_de_merge <- utr_de_merge %>% group_by(ID, ensembl_id, log2FC, `-log10(FDR)`, comparison) %>%
+      summarise(study_id = toString(study_id)) %>%
+      arrange(desc(abs(log2FC)))
+    return(utr_de_merge)
+  } else { return(use_table)}
 }
 
-add_study_corr <- function(use_table, study,
+add_study_corr <- function(use_table, study=unique(pub_genes_split$study_id),
                            de_filt = T) {
-  pub_genes_use <- filter(pub_genes_split, source %in% study)
+  pub_genes_use <- filter(pub_genes_split, study_id %in% study)
   corr_merge <- dplyr::rename(use_table, ID = gene)
   corr_merge <- dplyr::left_join(corr_merge, pub_genes_use, by = "ID")
   if(de_filt) {
     corr_merge <- corr_merge %>% group_by(pair, rho, fdr,mirna,ID, database,gene_comparison, mirna_comparison) %>%
-      summarise(source  = toString(source)) %>%
+      summarise(study_id  = toString(study_id)) %>%
       arrange(desc(abs(rho)))
   }
   else {
     corr_merge <- corr_merge %>% group_by(pair, rho, fdr,mirna,ID, database) %>%
-      summarise(source  = toString(source)) %>%
+      summarise(study_id  = toString(study_id)) %>%
       arrange(desc(abs(rho)))
   }
   return(corr_merge)


### PR DESCRIPTION
## Main changes:
### miRNA-gene target correlation
* `miRNA-Gene Target Correlation` tab is added
* Takes a list of comma-separated miRNAs or genes and returns negatively correlated genes or miRNAs (depends on input; will return the opposite type of data)
* Option to return pairs where both genes and miRNAs are DE or return all pairs (for sex-biased, returns if both gene and miRNA are sex-biased at any age; for age-biased returns if both gene and miRNA are age-biased from the same age comparison regardless of sex)
* Results can be outputted as:
i. .txt file containing interaction table for input to Cytoscape (ie. miRNA->gene, database, rho) 
ii. .txt file containing nodes table for input to Cytoscape (ie. miRNA/gene, node type, miRNA DE comparison, gene DE comparison)
iii. .txt file of miRNAs and genes from resulting correlation pairs which can be inputted to `Data Browser` for additional information

### Data Browser
* Default sex-biased gene/miRNA lists are available as input
* By default, gene lists from other studies are intersected with genes of interest (removed `Studies to intersect` option from side panel)
* Studies are now referred to as numbers; a legend is added to "Plot" and "DEG" panel
* Option to display DE genes and miRNAs with or without a log2FC/FDR cutoff

## Minor changes:
* Case-sensitivity is removed for genes/miRNA input (improper case should be automatically corrected for)
* Updated `About` to list citations for gene list compendium
* Moved gene list compendium button to `About`
* Fixed bug where single input of non-DE gene would throw an error
* Updated `Home` to include feature list from `miRNA-Gene Target Correlation` tab